### PR TITLE
Use endpoints provided by fabric8

### DIFF
--- a/src/addExtensions/addExtensions.ts
+++ b/src/addExtensions/addExtensions.ts
@@ -19,7 +19,7 @@ import { State } from "../definitions/state";
 import { ConfigManager } from "../definitions/configManager";
 import { MultiStepInput } from "../utils/multiStepUtils";
 import { pickExtensionsWithoutLastUsed } from "../generateProject/pickExtensions";
-import { QExtension } from "../definitions/qExtension";
+import { QExtension } from "../definitions/extension";
 
 export async function add(configManager: ConfigManager) {
   const state: Partial<State> = {

--- a/src/definitions/configManager.ts
+++ b/src/definitions/configManager.ts
@@ -16,7 +16,7 @@
 
 import { QUARKUS_CONFIG_NAME, DEFAULT_API_URL } from './projectGenerationConstants';
 import { workspace } from 'vscode';
-import { QExtension } from './qExtension';
+import { QExtension } from './extension';
 
 /**
  * This class manages the extension's interaction with

--- a/src/definitions/extension.ts
+++ b/src/definitions/extension.ts
@@ -14,10 +14,26 @@
  * limitations under the License.
  */
 
+/**
+* Interface representing a Quarkus extension
+*/
 export interface QExtension {
   name: string;
   labels: string[];
   groupId: string;
   artifactId: string;
-  guide?: string;
+}
+
+/**
+ * Interface representing a Quarkus extension
+ * from the extensions endpoint
+ */
+export interface APIExtension {
+  id: string;
+  name: string;
+  labels: string[];
+  description: string;
+  shortName: string;
+  category?: string;
+  order: Number;
 }

--- a/src/definitions/projectGenerationConstants.ts
+++ b/src/definitions/projectGenerationConstants.ts
@@ -15,7 +15,7 @@
  */
 
 // Constants related to project generation
-export const DEFAULT_API_URL: string = 'http://quarkus-generator.6923.rh-us-east-1.openshiftapps.com';
+export const DEFAULT_API_URL: string = 'https://code.quarkus.io/api/quarkus';
 export const DEFAULT_GROUP_ID: string = 'org.my.group';
 export const DEFAULT_ARTIFACT_ID: string = 'MyQuarkusProject';
 export const DEFAULT_PROJECT_VERSION: string = '1.0-SNAPSHOT';

--- a/src/definitions/state.ts
+++ b/src/definitions/state.ts
@@ -1,5 +1,5 @@
 import { Uri } from 'vscode';
-import { QExtension } from './qExtension';
+import { QExtension } from './extension';
 
 /**
  * Copyright 2019 Red Hat, Inc. and others.

--- a/src/generateProject/pickExtensions.ts
+++ b/src/generateProject/pickExtensions.ts
@@ -15,7 +15,7 @@
  */
 
 import { MultiStepInput } from '../utils/multiStepUtils';
-import { QExtension } from '../definitions/qExtension';
+import { QExtension } from '../definitions/extension';
 import { State } from '../definitions/state';
 import { SettingsJson } from '../definitions/configManager';
 import { getQExtensions } from '../utils/requestUtils';

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -16,28 +16,47 @@
 
 import * as request from 'request-promise';
 import * as unzipper from 'unzipper';
-import { QExtension } from '../definitions/qExtension';
+import { QExtension, APIExtension } from '../definitions/extension';
 import { State } from '../definitions/state';
 
 export async function getQExtensions(apiUrl: string): Promise<QExtension[]> {
 
-  return await request.get(`${apiUrl}/extension/list`)
+  return await request.get(`${apiUrl}/extensions`)
     .then((body) => {
-      const qExtensions: QExtension[] = JSON.parse(body);
+      const qExtensions: QExtension[] = convertToQExtensions(JSON.parse(body));
+
       return qExtensions.sort((a, b) => a.name.localeCompare(b.name));
     });
+}
+
+function convertToQExtensions(extensions: APIExtension[]): QExtension[] {
+  return extensions.map((extension) => {
+    const semicolon: number = extension.id.indexOf(':');
+    const groupId: string = extension.id.substring(0, semicolon);
+    const artifactId: string = extension.id.substring(semicolon + 1);
+    
+    return {
+      name: extension.name,
+      labels: extension.labels,
+      groupId,
+      artifactId
+    } as QExtension;
+  });
 }
 
 export async function downloadProject(state: State, apiUrl: string) {
 
   const chosenExtArtifactIds: string[] = state.extensions!.map((it) => it.artifactId);
+  const chosenIds: string[] = chosenExtArtifactIds.map((artifactId) => {
+    return 'io.quarkus:' + artifactId;
+  });
 
-  const qProjectUrl: string = `${apiUrl}/generator?` +
+  const qProjectUrl: string = `${apiUrl}/download?` +
     `g=${state.groupId}&` +
     `a=${state.artifactId}&` +
-    `pv=${state.projectVersion}&` +
-    `cn=${state.packageName}.${state.resourceName}&` +
-    `e=${chosenExtArtifactIds.join('&e=')}`;
+    `v=${state.projectVersion}&` +
+    `c=${state.packageName}.${state.resourceName}&` +
+    `e=${chosenIds.join('&e=')}`;
 
   return request(qProjectUrl)
   .pipe(unzipper.Extract({ path: state.targetDir!.fsPath })).promise();


### PR DESCRIPTION
Project generation and extensions list is now being retrieved from endpoints provided by  [launcher-quarkus](https://github.com/fabric8-launcher/launcher-quarkus).

The format of the extensions given by the endpoints from launcher-quarkus were different than the format of the extensions from before. After getting the list of extensions from their endpoint, I decided to [convert](https://github.com/xorye/vscode-quarkus/blob/728e86030101a4a778f4367d66736347f1a196b0/src/utils/requestUtils.ts#L33) it to match the [QExtensions interface](https://github.com/xorye/vscode-quarkus/blob/728e86030101a4a778f4367d66736347f1a196b0/src/definitions/extension.ts#L20) we have currently.

Signed-off-by: David Kwon <dakwon@redhat.com>