### PR TITLE
Add trace.server configuration property

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,17 @@
 		"configuration": {
 			"title": "Quarkus Tools",
 			"properties": {
+				"quarkus.tools.trace.server": {
+					"type": "string",
+					"enum": [
+						"off",
+						"messages",
+						"verbose"
+					],
+					"default": "off",
+					"description": "Traces the communication between VS Code and the Quarkus language server.",
+					"scope": "window"
+				},
 				"quarkus.tools.starter": {
 					"type": "object",
 					"properties": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,7 +78,7 @@ function connectToLS() {
     };
 
     const serverOptions = prepareExecutable(requirements);
-    languageClient = new LanguageClient('Quarkus', 'Quarkus Tools', serverOptions, clientOptions);
+    languageClient = new LanguageClient('quarkus.tools', 'Quarkus Tools', serverOptions, clientOptions);
     languageClient.start();
     return languageClient.onReady();
   });


### PR DESCRIPTION
Fixes #26 

![image](https://user-images.githubusercontent.com/20326645/63174795-aca4c500-c010-11e9-9036-e24c5893bd88.png)

The server id was renamed to `quarkus.tools`.

Signed-off-by: David Kwon <dakwon@redhat.com>