### PR TITLE
Remove unnecessary text

### DIFF
--- a/src/generateProject/pickExtensions.ts
+++ b/src/generateProject/pickExtensions.ts
@@ -83,7 +83,7 @@ async function pickExtensions(input: MultiStepInput, state: Partial<ProjectGenSt
       title: 'Quarkus Tools',
       step: input.getStepNumber(),
       totalSteps: state.totalSteps!,
-      placeholder: 'Pick extensions (placeholder)',
+      placeholder: 'Pick extensions',
       items: quickPickItems,
       activeItem: quickPickItems[0]
     });


### PR DESCRIPTION
When picking extensions, there was some text that was added a while back for experimental purposes but I forgot to remove it. This PR removes it.

Before:
![image](https://user-images.githubusercontent.com/20326645/63295961-f3f2b600-c29b-11e9-88b1-2b8d95e0ac45.png)


After:
![image](https://user-images.githubusercontent.com/20326645/63295952-ef2e0200-c29b-11e9-98c3-50bc7d064275.png)

Signed-off-by: David Kwon <dakwon@redhat.com>