### PR TITLE
Change debug port for Quarkus language server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ Step 2. Open the Debugging tab, select and run
 ## Debugging  
 ### Debugging the Quarkus language server:
 In an IDE of your choice, set the debugger configuration to connect
-to localhost, port 1054.  
+to localhost, port 1064.  
 
 If using VSCode, open `quarkus-ls/quarkus.ls/` in VSCode. The proper
 debugger configurations are already defined in `.vscode/`.

--- a/src/languageServer/javaServerStarter.ts
+++ b/src/languageServer/javaServerStarter.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 const glob = require('glob');
 
 const DEBUG = startedInDebugMode();
+const DEBUG_PORT = 1064;
 const SERVER_NAME = 'com.redhat.quarkus.ls-uber.jar';
 
 export function prepareExecutable(requirements: RequirementsData): Executable {
@@ -22,9 +23,9 @@ export function prepareExecutable(requirements: RequirementsData): Executable {
 function prepareParams(): string[] {
   const params: string[] = [];
   if (DEBUG) {
-    params.push('-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1054,quiet=y');
+    params.push(`-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${DEBUG_PORT},quiet=y`);
     // suspend=y is the default. Use this form if you need to debug the server startup code:
-    // params.push('-agentlib:jdwp=transport=dt_socket,server=y,address=1054');
+    // params.push(`-agentlib:jdwp=transport=dt_socket,server=y,address=${DEBUG_PORT}`);
   }
 
   const vmargs = workspace.getConfiguration("xml").get("server.vmargs", '');


### PR DESCRIPTION
Fixes #35 

The fix is two PRs. This one and https://github.com/redhat-developer/quarkus-ls/pull/45

The port was changed from 1054 to 1064. The `CONTRIBUTING.md` file was changed as well. 

Signed-off-by: David Kwon <dakwon@redhat.com>