### PR TITLE
Don't save apiUrl if using default apiUrl

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,58 +66,54 @@
 					"description": "Traces the communication between VS Code and the Quarkus language server.",
 					"scope": "window"
 				},
-				"quarkus.tools.starter": {
+				"quarkus.tools.starter.api": {
+					"type": "string",
+					"default": "http://code.quarkus.io/api/quarkus",
+					"pattern": "https?://.+",
+					"description": "Quarkus API base URL",
+					"scope": "window"
+				},
+				"quarkus.tools.starter.defaults": {
 					"type": "object",
+					"default": {},
+					"description": "Default values for the project generation wizard.",
+					"scope": "window",
 					"properties": {
-						"apiUrl": {
+						"groupId": {
 							"type": "string",
-							"pattern": "https?://.+",
+							"pattern": "^[A-Za-z0-9_\\-.]+$",
 							"scope": "window",
-							"description": "Quarkus API base URL"
+							"description": "Default Group Id"
 						},
-						"defaults": {
-							"default": {},
-							"type": "object",
-							"description": "Default values for the project generation wizard.",
+						"artifactId": {
+							"type": "string",
+							"pattern": "^[A-Za-z0-9_\\-.]+$",
 							"scope": "window",
-							"properties": {
-								"groupId": {
-									"type": "string",
-									"pattern": "^[A-Za-z0-9_\\-.]+$",
-									"scope": "window",
-									"description": "Default Group Id"
-								},
-								"artifactId": {
-									"type": "string",
-									"pattern": "^[A-Za-z0-9_\\-.]+$",
-									"scope": "window",
-									"description": "Default Artifact Id"
-								},
-								"projectVersion": {
-									"type": "string",
-									"pattern": "^[A-Za-z0-9_\\-.]+$",
-									"scope": "window",
-									"description": "Default project version"
-								},
-								"packageName": {
-									"type": "string",
-									"pattern": "^[A-Za-z0-9_\\-.]+$",
-									"scope": "window",
-									"description": "Default package name"
-								},
-								"resourceName": {
-									"type": "string",
-									"pattern": "^[A-Za-z0-9_\\-.]+$",
-									"scope": "window",
-									"description": "Default resource name"
-								},
-								"extensions": {
-									"default": [],
-									"type": "array",
-									"scope": "window",
-									"description": "Store previously selected Quarkus extensions"
-								}
-							}
+							"description": "Default Artifact Id"
+						},
+						"projectVersion": {
+							"type": "string",
+							"pattern": "^[A-Za-z0-9_\\-.]+$",
+							"scope": "window",
+							"description": "Default project version"
+						},
+						"packageName": {
+							"type": "string",
+							"pattern": "^[A-Za-z0-9_\\-.]+$",
+							"scope": "window",
+							"description": "Default package name"
+						},
+						"resourceName": {
+							"type": "string",
+							"pattern": "^[A-Za-z0-9_\\-.]+$",
+							"scope": "window",
+							"description": "Default resource name"
+						},
+						"extensions": {
+							"default": [],
+							"type": "array",
+							"scope": "window",
+							"description": "Store previously selected Quarkus extensions"
 						}
 					}
 				}

--- a/src/addExtensions/addExtensions.ts
+++ b/src/addExtensions/addExtensions.ts
@@ -19,7 +19,7 @@ import { State, AddExtensionsState } from "../definitions/inputState";
 import { ConfigManager } from "../definitions/configManager";
 import { MultiStepInput } from "../utils/multiStepUtils";
 import { pickExtensionsWithoutLastUsed } from "../generateProject/pickExtensions";
-import { QExtension } from "../definitions/extension";
+import { QExtension } from "../definitions/extensionInterfaces";
 
 export async function add(configManager: ConfigManager) {
   const state: Partial<AddExtensionsState> = {
@@ -60,7 +60,7 @@ export async function add(configManager: ConfigManager) {
   await collectInputs(state);
 
   if (state.wizardInterrupted) {
-    window.showErrorMessage('pom.xml could not be located.');
+    window.showErrorMessage(state.wizardInterrupted.reason);
     return;
   }
 

--- a/src/definitions/configManager.ts
+++ b/src/definitions/configManager.ts
@@ -14,49 +14,36 @@
  * limitations under the License.
  */
 
-import { QUARKUS_CONFIG_NAME, DEFAULT_API_URL } from './projectGenerationConstants';
+import { QUARKUS_STARTER_CONFIG_NAME, DEFAULT_API_URL } from './projectGenerationConstants';
 import { workspace } from 'vscode';
-import { QExtension } from './extension';
+import { QExtension } from './extensionInterfaces';
 
 /**
  * This class manages the extension's interaction with
+ * the `quarkus.tools.starter` configuration in
  * settings.json
  */
 
 export class ConfigManager {
 
-  apiUrl: string;
+  apiUrl?: string;
   defaults: Partial<Defaults>;
 
   constructor() {
-    this.apiUrl = DEFAULT_API_URL;
     this.defaults = {};
-
-    const settings = workspace.getConfiguration('').get<SettingsJson>(QUARKUS_CONFIG_NAME);
-
-    if (!settings) {
-      return;
-    }
-
-    if (settings.apiUrl) {
-      this.apiUrl = settings.apiUrl;
-    }
-
-    if (settings.defaults) {
-      this.defaults = settings.defaults;
-    }
+    this.apiUrl = workspace.getConfiguration(QUARKUS_STARTER_CONFIG_NAME).get('api');
+    this.defaults =  workspace.getConfiguration(QUARKUS_STARTER_CONFIG_NAME).get('defaults');
   }
 
   getSettingsJson(): SettingsJson {
     return {
-      apiUrl: this.apiUrl,
+      api: this.apiUrl,
       defaults: this.defaults
     } as SettingsJson;
   }
 
   saveDefaultsToConfig(defaults: Defaults) {
-    this.defaults = defaults;
-    workspace.getConfiguration().update('quarkus.tools.starter', {apiUrl: this.apiUrl, defaults: defaults}, true);
+      workspace.getConfiguration(QUARKUS_STARTER_CONFIG_NAME).update('defaults', defaults, true);
   }
 }
 
@@ -66,11 +53,11 @@ export class ConfigManager {
  * ie, contents of  workspace.getConfiguration('quarkus.tools.starter')
  */
 export interface SettingsJson {
-  apiUrl: string;
+  api?: string;
   defaults: Partial<Defaults>;
 }
 
-interface Defaults {
+export interface Defaults {
   groupId: string;
   artifactId: string;
   projectVersion: string;

--- a/src/definitions/extensionInterfaces.ts
+++ b/src/definitions/extensionInterfaces.ts
@@ -26,7 +26,7 @@ export interface QExtension {
 
 /**
  * Interface representing a Quarkus extension
- * from the extensions endpoint
+ * from the ${apiUrl}/extensions endpoint
  */
 export interface APIExtension {
   id: string;

--- a/src/definitions/inputState.ts
+++ b/src/definitions/inputState.ts
@@ -15,7 +15,7 @@
  */
 
 import { Uri } from 'vscode';
-import { QExtension } from './extension';
+import { QExtension } from './extensionInterfaces';
 
 export interface State {
   totalSteps: number;

--- a/src/definitions/projectGenerationConstants.ts
+++ b/src/definitions/projectGenerationConstants.ts
@@ -23,4 +23,4 @@ export const DEFAULT_PACKAGE_NAME: string = 'PackageName';
 export const DEFAULT_RESOURCE_NAME: string = 'ResourceName';
 export const INPUT_TITLE: string = 'Quarkus Tools';
 
-export const QUARKUS_CONFIG_NAME = 'quarkus.tools.starter';
+export const QUARKUS_STARTER_CONFIG_NAME = 'quarkus.tools.starter';

--- a/src/generateProject/generationWizard.ts
+++ b/src/generateProject/generationWizard.ts
@@ -144,19 +144,18 @@ export async function generateProject(configManager: ConfigManager) {
     extensions: state.extensions
   });
 
-  tryDownloadProject(state as ProjectGenState, settings.apiUrl);
+  tryDownloadProject(state as ProjectGenState, settings);
 }
 
-async function tryDownloadProject(state: ProjectGenState, apiUrl: string) {
+async function tryDownloadProject(state: ProjectGenState, settings: SettingsJson) {
   try {
-    await downloadProject(state, apiUrl);
+    await downloadProject(state, settings);
     const dirToOpen = Uri.file(path.join(state.targetDir.fsPath, state.artifactId));
     commands.executeCommand('vscode.openFolder', dirToOpen, true);
   } catch (err) {
     window.showErrorMessage(err);
   }
 }
-
 async function getTargetDirectory(projectName: string) {
   const MESSAGE_EXISTING_FOLDER = `'${projectName}' already exists in selected directory.`;
   const LABEL_CHOOSE_FOLDER = 'Generate Here';

--- a/src/generateProject/pickExtensions.ts
+++ b/src/generateProject/pickExtensions.ts
@@ -15,7 +15,7 @@
  */
 
 import { MultiStepInput } from '../utils/multiStepUtils';
-import { QExtension } from '../definitions/extension';
+import { QExtension } from '../definitions/extensionInterfaces';
 import { State } from '../definitions/inputState';
 import { SettingsJson } from '../definitions/configManager';
 import { getQExtensions } from '../utils/requestUtils';
@@ -66,7 +66,7 @@ async function pickExtensions(
   settings: SettingsJson,
   next: (input: MultiStepInput, state: Partial<State>) => any) {
 
-  const apiUrl = settings.apiUrl ? settings.apiUrl : DEFAULT_API_URL;
+  const apiUrl = settings.api ? settings.api : DEFAULT_API_URL;
 
   let allExtensions: QExtension[];
 

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -19,9 +19,11 @@ import * as yauzl from 'yauzl';
 import * as p from 'path';
 import * as fs from 'fs';
 
-import { QExtension, APIExtension } from '../definitions/extension';
+import { QExtension, APIExtension } from '../definitions/extensionInterfaces';
 import { ProjectGenState } from '../definitions/inputState';
+import { SettingsJson } from '../definitions/configManager';
 import { Readable } from 'stream';
+import { DEFAULT_API_URL } from '../definitions/projectGenerationConstants';
 
 export async function getQExtensions(apiUrl: string): Promise<QExtension[]> {
   const requestOptions = {
@@ -50,7 +52,9 @@ function convertToQExtensions(extensions: APIExtension[]): QExtension[] {
   });
 }
 
-export async function downloadProject(state: ProjectGenState, apiUrl: string) {
+export async function downloadProject(state: ProjectGenState, settings: SettingsJson) {
+
+  const apiUrl = settings.api ? settings.api : DEFAULT_API_URL;
 
   const chosenExtArtifactIds: string[] = state.extensions!.map((it) => it.artifactId);
   const chosenIds: string[] = chosenExtArtifactIds.map((artifactId) => {


### PR DESCRIPTION
Fixes #23

The `quarkus.tools.starter` configuration option currently looks like the following:
```
quarkus.tools.starter: {
    apiUrl: <STRING>
    defaults: {
        groupId: <STRING>
        artifactId: <STRING>
        ...
    }
}
```

How the defaults saving previously worked, was that when we wanted to save defaults, instead of only saving only the `quarkus.tools.starter.defaults` object, I had to save the whole `quarkus.tools.starter` object instead. I was unable to only update only the `defaults` part.

I've tried `workspace.getConfiguration('quarkus.tools.starter').update('defaults', <NEW DEFAULTS>, true);` and other variations of this, without success.

The line of code above runs with an error: `Error: Unable to write to User Settings because quarkus.tools.starter.defaults is not a registered configuration.`

This is because of how `quarkus.tools.starter` is defined in [`package.json`](https://github.com/xorye/vscode-quarkus/blob/323c7928dcd447a6be42bf31a587fd908ac0882f/package.json#L69).


This PR will save the apiUrl only if the apiUrl previously existed in `settings.json`, and doesn't save the apiUrl otherwise. This is done [here](https://github.com/xorye/vscode-quarkus/blob/323c7928dcd447a6be42bf31a587fd908ac0882f/src/definitions/configManager.ts#L57-L62).

It might be cleaner if we defined two configurations in `package.json` instead of one nested one: `quarkus.tools.starter`.
They could be `quarkus.tools.starter.api` and `quarkus.tools.starter.defaults`.
This separates saving for the apiUrl and defaults.
This would also improve user experience because defining `quarkus.tools.starter.api` separately allows the user to change apiUrl like the image below, without opening `settings.json`.
![image](https://user-images.githubusercontent.com/20326645/63459294-41009480-c422-11e9-9974-37b08b3adc5f.png)


If having only one configuration is good enough for our uses, then this PR leaves that as is.

Signed-off-by: David Kwon <dakwon@redhat.com>