### PR TITLE
Generate launch.json and tasks.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "activationEvents": [
     "onCommand:quarkusTools.createMavenProject",
     "onCommand:quarkusTools.addExtension",
+    "onCommand:quarkusTools.debugQuarkusProject",
     "onLanguage:quarkus-properties"
   ],
   "main": "./dist/extension",
@@ -59,6 +60,10 @@
       {
         "command": "quarkusTools.addExtension",
         "title": "Quarkus: Add extensions to current project"
+      },
+      {
+        "command": "quarkusTools.debugQuarkusProject",
+        "title": "Quarkus: Debug current Quarkus project"
       }
     ],
     "snippets": [
@@ -79,6 +84,17 @@
           ],
           "default": "off",
           "description": "Traces the communication between VS Code and the Quarkus language server.",
+          "scope": "window"
+        },
+        "quarkus.tools.debug.terminateProcessOnExit": {
+          "type": "string",
+          "enum": [
+            "Always terminate",
+            "Never terminate",
+            "Ask"
+          ],
+          "default": "Ask",
+          "description": "Determines whether to terminate the quarkus:dev task after closing the debug session.",
           "scope": "window"
         },
         "quarkus.tools.starter.api": {

--- a/src/QuarkusConfig.ts
+++ b/src/QuarkusConfig.ts
@@ -27,43 +27,51 @@ import { workspace } from 'vscode';
  * This class manages the extension's interaction with
  * settings.json
  */
-const QUARKUS_CONFIG_NAME = 'quarkus.tools.starter';
+const QUARKUS_CONFIG_NAME = 'quarkus.tools';
 
-export namespace Config {
+export namespace QuarkusConfig {
 
   export function getApiUrl(): string {
-    return getQuarkusToolsSection<string>('api', DEFAULT_API_URL);
+    return getQuarkusToolsSection<string>('starter.api', DEFAULT_API_URL);
   }
 
   export function getDefaultGroupId(): string {
-    return getQuarkusToolsSection<string>('defaults.groupId', DEFAULT_GROUP_ID);
+    return getQuarkusToolsSection<string>('starter.defaults.groupId', DEFAULT_GROUP_ID);
   }
 
   export function getDefaultArtifactId(): string {
-    return getQuarkusToolsSection<string>('defaults.artifactId', DEFAULT_ARTIFACT_ID);
+    return getQuarkusToolsSection<string>('starter.defaults.artifactId', DEFAULT_ARTIFACT_ID);
   }
 
   export function getDefaultProjectVersion(): string {
-    return getQuarkusToolsSection<string>('defaults.projectVersion', DEFAULT_PROJECT_VERSION);
+    return getQuarkusToolsSection<string>('starter.defaults.projectVersion', DEFAULT_PROJECT_VERSION);
   }
 
   export function getDefaultPackageName(): string {
-    return getQuarkusToolsSection<string>('defaults.packageName', DEFAULT_PACKAGE_NAME);
+    return getQuarkusToolsSection<string>('starter.defaults.packageName', DEFAULT_PACKAGE_NAME);
   }
 
   export function getDefaultResourceName(): string {
-    return getQuarkusToolsSection<string>('defaults.resourceName', DEFAULT_RESOURCE_NAME);
+    return getQuarkusToolsSection<string>('starter.defaults.resourceName', DEFAULT_RESOURCE_NAME);
   }
 
   export function getDefaultExtensions(): any[] {
-    return getQuarkusToolsSection<string[]>('defaults.extensions', []);
+    return getQuarkusToolsSection<string[]>('starter.defaults.extensions', []);
   }
 
-  export function saveDefaults(defaults: Defaults) {
-    workspace.getConfiguration(QUARKUS_CONFIG_NAME).update('defaults', defaults, true);
+  export function getTerminateProcessOnDebugExit(): TerminateProcessConfig {
+    return getQuarkusToolsSection<TerminateProcessConfig>('debug.terminateProcessOnExit');
   }
 
-  function getQuarkusToolsSection<T>(section: string, fallback: T): T {
+  export function saveDefaults(defaults: Defaults): void {
+    workspace.getConfiguration(QUARKUS_CONFIG_NAME).update('starter.defaults', defaults, true);
+  }
+
+  export function saveTerminateProcessOnDebugExit(save: string): void {
+    workspace.getConfiguration(QUARKUS_CONFIG_NAME).update('debug.terminateProcessOnExit', save, true);
+  }
+
+  function getQuarkusToolsSection<T>(section: string, fallback?: T): T|undefined {
     return workspace.getConfiguration(QUARKUS_CONFIG_NAME).get<T>(section, fallback);
   }
 }
@@ -75,4 +83,10 @@ interface Defaults {
   packageName: string;
   resourceName: string;
   extensions: string[];
+}
+
+export enum TerminateProcessConfig {
+  Ask = "Ask",
+  Terminate = "Always terminate",
+  DontTerminate = "Never terminate"
 }

--- a/src/addExtensions/addExtensionsWizard.ts
+++ b/src/addExtensions/addExtensionsWizard.ts
@@ -18,9 +18,10 @@ import { MultiStepInput } from "../utils/multiStepUtils";
 import { QExtension } from "../definitions/QExtension";
 import { QuickPickItem, RelativePattern, Uri, WorkspaceFolder, window, workspace } from "vscode";
 import { executeMavenCommand } from "../terminal/quarkusTerminalUtils";
+import { getPomPathsFromWorkspace } from "../utils/workspaceUtils";
 import { pickExtensionsWithoutLastUsed } from "../generateProject/pickExtensions";
 
-export async function add() {
+export async function addExtensionsWizard() {
   const state: Partial<AddExtensionsState> = {
     totalSteps: 1
   };
@@ -78,18 +79,15 @@ function getArtifactIds(extensions: QExtension[]): string[] {
  * files, under every currently opened workspace folder.
  */
 async function searchPomXml(): Promise<Uri[]> {
-  const pattern: string = '**/pom.xml';
   const workspaceFolders: WorkspaceFolder[] | undefined = workspace.workspaceFolders;
 
   if (workspaceFolders === undefined) {
     return [];
   }
 
-  const folderPaths: Uri[] = workspaceFolders.map((folder) => folder.uri);
-
-  const pomPaths: Uri[] = await folderPaths.reduce(async (pomPaths: Promise<Uri[]>, folderToSearch: Uri) => {
+  const pomPaths: Uri[] = await workspaceFolders.reduce(async (pomPaths: Promise<Uri[]>, folderToSearch: WorkspaceFolder) => {
     const accumulator = await pomPaths;
-    const pomFileUris: Uri[] = await workspace.findFiles(new RelativePattern(folderToSearch.fsPath, pattern));
+    const pomFileUris: Uri[] = await getPomPathsFromWorkspace(folderToSearch);
 
     return Promise.resolve(accumulator.concat(pomFileUris));
   }, Promise.resolve([]));

--- a/src/debugging/createDebugConfig.ts
+++ b/src/debugging/createDebugConfig.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2019 Red Hat, Inc. and others.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { Uri, workspace } from 'vscode';
+
+export function createDebugConfig(directory: Uri) {
+
+  const vscodeDir: string = directory.fsPath + '/.vscode';
+  if (!fs.existsSync(vscodeDir)) {
+    fs.mkdirSync(vscodeDir);
+  }
+
+  let tasksContent: string = getDebugConfigFile('tasks.json');
+  let launchContent: string = getDebugConfigFile('launch.json');
+
+  const insertSpaces: boolean = workspace.getConfiguration('editor').get('insertSpaces');
+  if (insertSpaces) {
+    const numSpaces: number = workspace.getConfiguration('editor').get('tabSize');
+    tasksContent = replaceTabsWithSpaces(tasksContent, numSpaces);
+    launchContent = replaceTabsWithSpaces(launchContent, numSpaces);
+  }
+
+  fs.writeFileSync(vscodeDir + '/tasks.json', tasksContent);
+  fs.writeFileSync(vscodeDir + '/launch.json', launchContent);
+}
+
+function getDebugConfigFile(filename: string): string {
+  const pathToFile = path.resolve(__dirname, '../vscode-debug-files/' + filename);
+  return fs.readFileSync(pathToFile).toString();
+}
+
+function replaceTabsWithSpaces(originalStr: string, numSpaces: number): string {
+  return originalStr.replace(/\t/g, ' '.repeat(numSpaces));
+}

--- a/src/debugging/startDebugging.ts
+++ b/src/debugging/startDebugging.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2019 Red Hat, Inc. and others.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { WorkspaceFolder, debug, window, workspace, DebugConfiguration } from 'vscode';
+import { containsMavenQuarkusProject } from '../utils/workspaceUtils';
+import { getQuarkusDevDebugConfig } from '../utils/launchConfigUtils';
+
+export async function tryStartDebugging() {
+  try {
+    await startDebugging();
+  } catch (message) {
+    window.showErrorMessage(message);
+  }
+}
+
+async function startDebugging(): Promise<void> {
+
+  const workspaceFolder: WorkspaceFolder = getDebugWorkspace();
+
+  if (!(await containsMavenQuarkusProject(workspaceFolder))) {
+    throw 'Current workspace folder does not contain a Maven project.';
+  }
+
+  const debugConfig: DebugConfiguration|undefined = await getQuarkusDevDebugConfig(workspaceFolder);
+  if (!debugConfig) {
+    throw 'Current workspace folder does not contain a debug configuration that starts the quarkus:dev command.';
+  }
+
+  debug.startDebugging(workspaceFolder, debugConfig);
+}
+
+function getDebugWorkspace(): WorkspaceFolder {
+
+  const workspaceFolders: WorkspaceFolder[]|undefined = workspace.workspaceFolders;
+
+  if (!workspaceFolders) {
+    throw 'No workspace folders are opened.';
+  }
+
+  if (workspaceFolders.length === 1) {
+    return workspace.workspaceFolders[0];
+  }
+
+  // try to return workspace folder containing currently opened file
+  const currentDoc = window.activeTextEditor.document.uri;
+  if (currentDoc && workspace.getWorkspaceFolder(currentDoc)) {
+    return workspace.getWorkspaceFolder(currentDoc);
+  }
+
+  // TODO maybe implement an input box to determine which workspace folder to debug in
+  return workspace.workspaceFolders[0]; // dummy return statement
+}

--- a/src/debugging/terminateProcess.ts
+++ b/src/debugging/terminateProcess.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2019 Red Hat, Inc. and others.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QuarkusConfig, TerminateProcessConfig } from '../QuarkusConfig';
+import { DebugSession, TaskExecution, debug, window } from 'vscode';
+import { Disposable } from 'vscode-languageclient';
+import { getRunningQuarkusDevTasks } from '../utils/tasksUtils';
+
+export function createTerminateDebugListener(disposables: Disposable[]): Disposable {
+
+  return debug.onDidTerminateDebugSession(async (debugSession: DebugSession) => {
+
+    let quarkusDevTaskExe: TaskExecution;
+
+    try {
+      checkHasPreLaunchTask(debugSession);
+      quarkusDevTaskExe = await getPreLaunchTaskExecution(debugSession);
+    } catch (message) {
+      // debugger for a non Quarkus project has terminated
+      // don't display an error message
+      return;
+    }
+
+    const terminate: boolean = await getUserInputTerminate();
+
+    if (terminate) {
+      quarkusDevTaskExe.terminate();
+    }
+
+  }, null, disposables);
+}
+
+function checkHasPreLaunchTask(debugSession: DebugSession): void {
+  if (typeof debugSession.configuration.preLaunchTask === 'undefined') {
+    throw 'Pre launch task does not exist';
+  }
+}
+
+async function getPreLaunchTaskExecution(debugSession: DebugSession): Promise<TaskExecution> {
+
+  const preLaunchTask: string = debugSession.configuration.preLaunchTask;
+
+  // Get quarkus:dev tasks from the debugSession's workspace folder
+  const runningQuarkusDevTasks: TaskExecution[] = await getRunningQuarkusDevTasks(debugSession.workspaceFolder);
+
+  for (const taskExe of runningQuarkusDevTasks) {
+    if (taskExe.task.name === preLaunchTask) {
+      return taskExe;
+    }
+  }
+  throw `Task named ${preLaunchTask} is not a running quarkus:dev task in closed debug session's WorkspaceFolder`;
+}
+
+function saveToConfig(terminate: boolean, askAgain: boolean): void {
+  let save: TerminateProcessConfig;
+  if (askAgain) {
+    save = TerminateProcessConfig.Ask;
+  } else if (terminate) {
+    save = TerminateProcessConfig.Terminate;
+  } else if (!terminate) {
+    save = TerminateProcessConfig.DontTerminate;
+  }
+  QuarkusConfig.saveTerminateProcessOnDebugExit(save);
+}
+
+async function getUserInputTerminate(): Promise<boolean> {
+  const terminateConfig: TerminateProcessConfig = QuarkusConfig.getTerminateProcessOnDebugExit();
+
+  if (terminateConfig === TerminateProcessConfig.Ask) {
+    const TERM_TASK = 'Terminate task';
+    const DONT_TERM_TASK = 'Keep task running';
+    const REMEMBER = 'Remember my choice';
+    const ASK_AGAIN = 'Ask again next time';
+
+    const terminateInput: string | undefined = await window.showInformationMessage('Debug session was terminated. Would you like to terminate the quarkus:dev task?', TERM_TASK, DONT_TERM_TASK);
+
+    if (typeof terminateInput === 'undefined') {
+      return false;
+    }
+    const terminate: boolean = terminateInput === TERM_TASK;
+    const rememberMessage = `Do you want to always ${terminate ? 'terminate the task': 'keep the task running'}?`;
+    const rememberInput: string | undefined = await window.showInformationMessage(rememberMessage, REMEMBER, ASK_AGAIN);
+
+    if (typeof rememberInput === 'undefined') {
+      return terminate;
+    }
+
+    const askAgain: boolean = rememberInput === ASK_AGAIN;
+    saveToConfig(terminate, askAgain);
+
+    return terminateInput === TERM_TASK;
+  }
+
+  return terminateConfig === TerminateProcessConfig.Terminate;
+}

--- a/src/generateProject/pickExtensions.ts
+++ b/src/generateProject/pickExtensions.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { QUARKUS_GROUP_ID } from '../definitions/wizardConstants';
-import { Config } from '../Config';
+import { QuarkusConfig } from '../QuarkusConfig';
 import { MultiStepInput } from '../utils/multiStepUtils';
 import { QExtension } from '../definitions/QExtension';
 import { State } from '../definitions/inputState';
@@ -130,7 +130,7 @@ async function pickExtensions(
 
 function getDefaultQExtensions(allExtensions: QExtension[]): QExtension[] {
   const result: QExtension[] = [];
-  let defaultExtensionIds: any[] = Config.getDefaultExtensions();
+  let defaultExtensionIds: any[] = QuarkusConfig.getDefaultExtensions();
 
   defaultExtensionIds = defaultExtensionIds.filter((extensionId: any) => {
     return typeof extensionId === 'string' && extensionId.length > 0;
@@ -171,7 +171,7 @@ function getItems(selected: QExtension[], unselected: QExtension[], defaults: QE
     detail: 'Press <Enter>  to continue'
   });
 
-  if (selected.length === 0 && defaults.length > 0 && addLastUsed) { // TODO pass default extensions to this function. if exists, run addLastUsedOption
+  if (selected.length === 0 && defaults.length > 0 && addLastUsed) {
     addLastUsedOption(items, defaults);
   }
 

--- a/src/utils/launchConfigUtils.ts
+++ b/src/utils/launchConfigUtils.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2019 Red Hat, Inc. and others.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DebugConfiguration, Task, WorkspaceFolder, workspace } from 'vscode';
+import { getQuarkusDevTasks } from '../utils/tasksUtils';
+
+export async function getQuarkusDevDebugConfig(workspaceFolder: WorkspaceFolder): Promise<DebugConfiguration | undefined> {
+  const debugConfig: DebugConfiguration[] = getConfigsWithPreLaunchTask(workspaceFolder);
+  const quarkusDevTasks: Task[] = await getQuarkusDevTasks(workspaceFolder);
+  const devTasksNames: string[] = quarkusDevTasks.map((task: Task) => {
+    return task.name;
+  });
+
+  for (const config of debugConfig) {
+    if (devTasksNames.includes(config.preLaunchTask)) {
+      return config;
+    }
+  }
+
+  return undefined;
+}
+
+export function getConfigsWithPreLaunchTask(workspaceFolder: WorkspaceFolder): DebugConfiguration[] {
+  return getLaunchConfig(workspaceFolder).filter((config: DebugConfiguration) => {
+    return typeof config.preLaunchTask !== undefined;
+  });
+}
+
+export function getLaunchConfig(workspaceFolder: WorkspaceFolder): DebugConfiguration[] {
+  return workspace.getConfiguration('launch', workspaceFolder.uri).get<DebugConfiguration[]>('configurations');
+}

--- a/src/utils/tasksUtils.ts
+++ b/src/utils/tasksUtils.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2019 Red Hat, Inc. and others.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as _ from 'lodash';
+
+import { tasks, ProcessExecution, ShellExecution, Task, TaskExecution, WorkspaceFolder } from 'vscode';
+
+export async function getQuarkusDevTasks(workspaceFolder: WorkspaceFolder): Promise<Task[]> {
+  const workspaceTasks: Task[] = await getTasksFromWorkspace(workspaceFolder);
+  return workspaceTasks.filter((task: Task) => {
+    return isQuarkusDevTask(task);
+  });
+}
+
+export async function getTasksFromWorkspace(workspaceFolder: WorkspaceFolder): Promise<Task[]> {
+  const allTasks: Task[] = await tasks.fetchTasks();
+  return allTasks.filter((task: Task) => {
+    return isTaskFromWorkspace(workspaceFolder, task);
+  });
+}
+
+export async function getRunningQuarkusDevTasks(workspaceFolder: WorkspaceFolder): Promise<TaskExecution[]> {
+  const runningTasksInWorkspace: TaskExecution[] = tasks.taskExecutions.filter(taskExe => {
+    return isTaskFromWorkspace(workspaceFolder, taskExe.task);
+  });
+
+  const quarkusDevTasks: Task[] = await getQuarkusDevTasks(workspaceFolder);
+
+  return runningTasksInWorkspace.filter((runningTask: TaskExecution) => {
+    return quarkusDevTasks.some((task: Task) => {
+      return _.isEqual(runningTask.task, task);
+    });
+  });
+}
+
+function isQuarkusDevTask(task: Task): boolean {
+  const execution: ProcessExecution | ShellExecution = task.execution;
+  return 'commandLine' in execution && execution.commandLine.includes('quarkus:dev');
+}
+
+function isTaskFromWorkspace(workspaceFolder: WorkspaceFolder, task: Task): boolean {
+
+  // check if task.scope is a WorkspaceFolder
+  if (Object(task.scope) !== task.scope) {
+    return false;
+  }
+
+  const taskWorkspace: WorkspaceFolder = task.scope as WorkspaceFolder;
+  return taskWorkspace.uri === workspaceFolder.uri;
+}

--- a/src/utils/workspaceUtils.ts
+++ b/src/utils/workspaceUtils.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2019 Red Hat, Inc. and others.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RelativePattern, Uri, WorkspaceFolder, workspace } from "vscode";
+
+export async function containsMavenQuarkusProject(workspaceFolder: WorkspaceFolder): Promise<boolean> {
+  // TODO this function must be improved. It only checks if a file named
+  // pom.xml exists under the provided workspaceFolder
+  return (await getPomPathsFromWorkspace(workspaceFolder)).length > 0;
+}
+
+export async function getPomPathsFromWorkspace(workspaceFolder: WorkspaceFolder): Promise<Uri[]> {
+  const pattern: string = '**/pom.xml';
+  workspace.findFiles(new RelativePattern(workspaceFolder.uri.fsPath, pattern)).then((ff) => {
+    const i = 0;
+  });
+
+  return workspace.findFiles(new RelativePattern(workspaceFolder.uri.fsPath, pattern));
+}

--- a/vscode-debug-files/launch.json
+++ b/vscode-debug-files/launch.json
@@ -1,0 +1,16 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"preLaunchTask": "quarkus:dev",
+			"type": "java",
+			"request": "attach",
+			"hostName": "localhost",
+			"name": "Debug Quarkus application",
+			"port": 5005
+		}
+	]
+}

--- a/vscode-debug-files/tasks.json
+++ b/vscode-debug-files/tasks.json
@@ -1,0 +1,33 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "quarkus:dev",
+			"type": "shell",
+			"command": "./mvnw quarkus:dev",
+			"windows": {
+				"command": ".\\mvn.cmd quarkus:dev"
+			},
+			"isBackground": true,
+			"problemMatcher": [
+				{
+					"pattern": [
+						{
+							"regexp": "\\b\\B",
+							"file": 1,
+							"location": 2,
+							"message": 3
+						}
+					],
+					"background": {
+						"activeOnStart": true,
+						"beginsPattern": "^.*Scanning for projects...*",
+						"endsPattern": "^.*Quarkus .* started in .*\\. Listening on:*"
+					}
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Fixes #13 

When the user creates a new Quarkus project with the "Quarkus: Generate a Maven project" command, the new Quarkus debug config will be created:
![image](https://user-images.githubusercontent.com/20326645/64273190-cef27a00-cf0e-11e9-9feb-9cf225ba0fe6.png)

This allows the user to hit F5 to debug, and have the mvn quarkus:dev command run automatically.

When the user exits the debug session, they are presented with this modal:
![image](https://user-images.githubusercontent.com/20326645/64273491-6bb51780-cf0f-11e9-8715-ff7a9c466ef9.png)

Clicking 'Cancel' will close the modal and will not terminate the quarkus:dev task.
Clicking 'Yes' or 'No' will cause a new modal to appear:
![image](https://user-images.githubusercontent.com/20326645/64273548-89827c80-cf0f-11e9-8dd8-5ec051c21e37.png)

For this modal, clicking 'Cancel' has the same effect as clicking 'No'.
If 'Yes' is clicked, the two modals will not show up again, and the quarkus:dev task will terminate or will not terminate (depending on what the user clicked earlier) everytime the debug session is closed.
If 'No' is clicked, the two modals will show up again when a debug session is closed.

The user can also set the behaviour in VS Code settings:
![image](https://user-images.githubusercontent.com/20326645/64274600-addf5880-cf11-11e9-8f21-78a6b5c2247d.png)

There is one problem I found, however. If the user follows these steps:
1. Open VS Code
2. Open Quarkus project folder, but don't open any files
3. Set the config to 'Always terminate'
![image](https://user-images.githubusercontent.com/20326645/64274627-bf286500-cf11-11e9-93e5-a054af6d1455.png)
4. Start the debug session with F5.
5. Close the debug session

In this case, we would expect that the quarkus:dev task to terminate, but it does not. This is because vscode-quarkus is not running. It is not running because the user did not invoke a vscode-quarkus command / did not open application.properties. To fix this, there needs to be a way to start the vscode-quarkus extension when debugging a Quarkus project.

Signed-off-by: David Kwon <dakwon@redhat.com>