### PR TITLE
Support for `textDocument/documentSymbol` as tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This extension provides several code snippets, available when editing Java files
 The following settings are supported:
   
 * `quarkus.tools.trace.server` : Trace the communication between VS Code and the Quarkus Language Server in the Output view.
+* `quarkus.tools.symbols.showAsTree` : Show Quarkus properties as tree (Outline). Default is `true`.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -129,6 +129,12 @@
 							"description": "Store previously selected Quarkus extensions"
 						}
 					}
+        },
+        "quarkus.tools.symbols.showAsTree": {
+					"type": "boolean",
+					"default": "true",
+					"description": "Show Quarkus properties as tree",
+					"scope": "window"
 				}
 			}
 		},


### PR DESCRIPTION
Support for `textDocument/documentSymbol` as tree

See https://github.com/redhat-developer/quarkus-ls/issues/72

Signed-off-by: azerr <azerr@redhat.com>