### PR TITLE
Add validation severity setting for syntax checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The following settings are supported:
 * `quarkus.tools.trace.server` : Trace the communication between VS Code and the Quarkus Language Server in the Output view.
 * `quarkus.tools.symbols.showAsTree` : Show Quarkus properties as tree (Outline). Default is `true`.
 * `quarkus.tools.validation.enabled` : Enables Quarkus validation. Default is `true`.
+* `quarkus.tools.validation.syntax.severity` : Validation severity for Quarkus property syntax checking.
+Default is `error`.
 * `quarkus.tools.validation.unknown.severity` : Validation severity for unknown Quarkus properties. Default is `warning`.
 * `quarkus.tools.validation.unknown.excluded` : Array of properties to ignore for unknown Quarkus properties validation. Default is `[]`.
         

--- a/package.json
+++ b/package.json
@@ -155,6 +155,17 @@
           "description": "Validation severity for unknown Quarkus properties.",
           "scope": "window"
         },
+        "quarkus.tools.validation.syntax.severity": {
+          "type": "string",
+          "enum": [
+            "none",
+            "warning",
+            "error"
+          ],
+          "default": "error",
+          "description": "Validation severity for Quarkus property syntax checking.",
+          "scope": "window"
+        },
         "quarkus.tools.validation.unknown.excluded": {
           "type": "array",
           "default": [],


### PR DESCRIPTION
Added settings to set validation severity for syntax checking for application.properties. 

This PR complements this PR made in quarkus-ls: https://github.com/redhat-developer/quarkus-ls/pull/84

Signed-off-by: David Kwon <dakwon@redhat.com>