### PR TITLE
Generate launch.json tasks.json when needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1195,6 +1195,17 @@
 			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
 			"dev": true
 		},
+		"comment-json": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/comment-json/-/comment-json-2.1.0.tgz",
+			"integrity": "sha512-OcO+nJnUtp29j9SwHVcP/F8t/9piiOQj7APXTj75cK/qFAgX7PtGV31ullzwZbBwiA5Rmj25C32FaFgwcu1Uwg==",
+			"requires": {
+				"core-util-is": "^1.0.2",
+				"esprima": "^4.0.1",
+				"has-own-prop": "^2.0.0",
+				"repeat-string": "^1.6.1"
+			}
+		},
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1281,8 +1292,7 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"create-ecdh": {
 			"version": "4.0.3",
@@ -1696,8 +1706,7 @@
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esrecurse": {
 			"version": "4.2.1",
@@ -3032,6 +3041,11 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
+		},
+		"has-own-prop": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
+			"integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ=="
 		},
 		"has-symbols": {
 			"version": "1.0.0",
@@ -4805,8 +4819,7 @@
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
 		"replace-ext": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -236,6 +236,7 @@
     "@types/request-promise": "^4.1.44",
     "@types/unzipper": "^0.9.2",
     "@types/yauzl": "^2.9.1",
+    "comment-json": "^2.1.0",
     "expand-home-dir": "0.0.3",
     "find-java-home": "^1.0.0",
     "find-up": "^4.1.0",
@@ -246,8 +247,8 @@
     "request-promise": "^4.2.4",
     "user-home": "^2.0.0",
     "vscode-languageclient": "^5.2.1",
+    "which": "^1.3.1",
     "xml2js": "^0.4.19",
-    "yauzl": "^2.10.0",
-    "which": "^1.3.1"
+    "yauzl": "^2.10.0"
   }
 }

--- a/src/debugging/startDebugging.ts
+++ b/src/debugging/startDebugging.ts
@@ -16,6 +16,7 @@
 
 import { WorkspaceFolder, debug, window, workspace, DebugConfiguration } from 'vscode';
 import { containsMavenQuarkusProject } from '../utils/workspaceUtils';
+import { createDebugConfig } from '../debugging/createDebugConfig';
 import { getQuarkusDevDebugConfig } from '../utils/launchConfigUtils';
 
 export async function tryStartDebugging() {
@@ -34,9 +35,11 @@ async function startDebugging(): Promise<void> {
     throw 'Current workspace folder does not contain a Maven project.';
   }
 
-  const debugConfig: DebugConfiguration|undefined = await getQuarkusDevDebugConfig(workspaceFolder);
+  let debugConfig: DebugConfiguration|undefined = await getQuarkusDevDebugConfig(workspaceFolder);
+
   if (!debugConfig) {
-    throw 'Current workspace folder does not contain a debug configuration that starts the quarkus:dev command.';
+    await createDebugConfig(workspaceFolder.uri);
+    debugConfig = await getQuarkusDevDebugConfig(workspaceFolder);
   }
 
   debug.startDebugging(workspaceFolder, debugConfig);

--- a/src/generateProject/generationWizard.ts
+++ b/src/generateProject/generationWizard.ts
@@ -203,7 +203,6 @@ async function downloadAndSetupProject(state: ProjectGenState): Promise<void> {
   const projectDir = getNewProjectDirectory(state);
   const zip: ZipFile = await downloadProject(state);
   zip.on('end', () => {
-    createDebugConfig(projectDir);
     commands.executeCommand('vscode.openFolder', projectDir, true);
   });
 }

--- a/vscode-debug-files/launch.json
+++ b/vscode-debug-files/launch.json
@@ -1,7 +1,7 @@
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-	// Use IntelliSense to learn about possible attributes.
-	// Hover to view descriptions of existing attributes.
-	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 	"version": "0.2.0",
 	"configurations": [
 		{

--- a/vscode-debug-files/tasks.json
+++ b/vscode-debug-files/tasks.json
@@ -1,6 +1,6 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
 {
-	// See https://go.microsoft.com/fwlink/?LinkId=733558
-	// for the documentation about the tasks.json format
 	"version": "2.0.0",
 	"tasks": [
 		{


### PR DESCRIPTION
Fixes #80 

### What this PR does:
When the debug command is called and the debug configuration that starts the quarkus:dev task could not be found, this PR will try to add a new debug configuration (to launch.json) and new quarkus:dev task (to tasks.json).

If the launch.json file already exists, the new debug configuration will be appended to the `configurations` array in the existing launch.json file. If the launch.json file does not exist, a new launch.json file containing the new debug configuration will be created.

Same goes for the quarkus:dev task and the tasks.json file. If the tasks.json file exists, it will append the new task into the `tasks` array. If not, the file is created.

The reason why I added the comment-json npm module was because I wanted to parse a JSON string that contained comments within the JSON. In other words, I wanted to read [these](https://github.com/xorye/vscode-quarkus/tree/80generate_launch_needed/vscode-debug-files) files as a string, then parse it into a javascript object.

Signed-off-by: David Kwon <dakwon@redhat.com>