### PR TITLE
Ideas for the welcome page

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ When editing `application.properties` files, you have access to:
 
 The following settings are supported:
   
+* `quarkus.tools.alwaysShowWelcomePage` : Determines whether to show the welcome page on extension startup.
+* `quarkus.tools.debug.terminateProcessOnExit` : Determines whether to terminate the quarkus:dev task after closing the debug session.
 * `quarkus.tools.trace.server` : Trace the communication between VS Code and the Quarkus Language Server in the Output view.
 * `quarkus.tools.symbols.showAsTree` : Show Quarkus properties as tree (Outline). Default is `true`.
 * `quarkus.tools.validation.enabled` : Enables Quarkus validation. Default is `true`.

--- a/WELCOME.md
+++ b/WELCOME.md
@@ -1,0 +1,130 @@
+# Quarkus Tools for Visual Studio Code
+This extension provides tools to get you up and running with Quarkus
+application development in Visual Studio Code.
+
+Maven 3.5.3+ supported
+
+[Create a new Maven based Quarkus project]() or open an existing Quarkus project to get started.
+<!-- The link for "Create a new Quarkus project" above would ideally start the wizard to
+generate a new Quarkus project -->
+
+## Requirements
+The [Java Extension Pack](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack) is highly recommended.
+
+* Java JDK (or JRE) 8 or more recent
+* [Language Support for Java(TM) by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.java)
+* [Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug)
+
+## New to Quarkus?
+Refer to the Quarkus Getting Started guide. The guide provides instructions from
+starting your first project, to creating a native executable. 
+
+[View Getting Started guide](https://quarkus.io/get-started/)
+
+[View Quarkus Cheat-Sheet](https://lordofthejars.github.io/quarkus-cheat-sheet/)
+
+## Documentation
+The Quarkus guides from quarkus.io/guides provides detailed documentation and
+tutorials for different use cases.
+
+[View guides]()
+
+## Sample projects
+Explore a wide variety of Quarkus quickstart projects, each focusing on a different aspect
+of Quarkus application development.
+
+[View quickstart projects](https://github.com/quarkusio/quarkus-quickstarts)
+
+## Getting help
+Keep in touch with the Quarkus community; there are many ways to reach out.
+
+[View community links](https://quarkus.io/community/)
+<!---
+Instead of the GitHub link I think it would be nice if it links to a page showing all 
+of the quick start projects, similiar to the IBM's "Follow Tutorials" link
+-->
+
+<!---
+Since there are so many guides, it would be better to link to a VS Code webview
+showing all the guides.
+-->
+
+
+<!---
+All the guides are below:
+-->
+
+<!-- ### Core
+* Configuring Your Application
+* Application Initialization and Termination
+* Contexts and Dependency Injection
+* Testing Your Application
+* Configuring Logging
+* Using SSL With Native Images
+* Context Propagation
+### Web
+* Writing REST JSON Services
+* Validation with Hibernate Validator
+* Using the REST Client
+* Using JWT RBAC
+* Using WebSockets
+* Using OpenAPI and Swagger UI
+* Undertow Reference Documentation
+* Using Fault Tolerance
+### Data
+* Configuring your datasources
+* Using Hibernate ORM and JPA
+* Simplified Hibernate ORM with Panache
+* Hibernate Search + Elasticsearch
+* Using Infinispan Client
+* Using Transactions
+* Validation with Hibernate Validator
+* Schema Migration with Flyway
+* Reactive Postgres Client
+* MongoDB Client
+* Neo4j Client
+### Messaging
+* Using Apache Kafka
+* Using AMQP with Reactive Messaging
+* Using Apache Kafka Streams
+* Asynchronous Message Passing
+### Security
+* Using Security
+* Using JWT RBAC
+* Using Keycloak to Protect JAX-RS Applications
+* Using OAuth2 RBAC
+### Business Automation
+* Using Kogito to add business automation capabilities to an application
+### Cloud
+* Deploying Native Applications on Kubernetes or OpenShift
+* Deploying Native Applications on Knative Kubernetes or OpenShift
+* Generating Kubernetes Resources
+* Using the Kubernetes Client to Interact with a Kubernetes Cluster
+* Deploying to OpenShift using S2I
+* Deploying to Microsoft Azure Cloud
+### Observability
+* Using Health Check
+* Using OpenTracing
+* Collecting Metrics
+* Using Fault Tolerance
+### Serialization
+* Writing REST JSON Services
+### Tooling
+* Building Applications with Maven
+* Building Applications with Gradle
+* Measuring the coverage of your tests
+### Migration
+* Using the Quarkus Extension for Spring DI API
+* Using the Quarkus Extension for Spring Web API
+* Using the Quarkus Extension for Spring Data JPA API
+### Writing Extensions
+* Writing Your Own Extension
+* Writing Native Applications
+### Alternative Languages
+* Using Kotlin
+### Miscellaneous
+* Scheduling Periodic Tasks
+* Sending Emails
+* Extracting Content with Apache Tika
+* Using Vert.x
+* Measuring Performance -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,9 +44,9 @@
 			}
 		},
 		"@types/lodash": {
-			"version": "4.14.134",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.134.tgz",
-			"integrity": "sha512-2/O0khFUCFeDlbi7sZ7ZFRCcT812fAeOLm7Ev4KbwASkZ575TDrDcY7YyaoHdTOzKcNbfiwLYZqPmoC4wadrsw=="
+			"version": "4.14.141",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.141.tgz",
+			"integrity": "sha512-v5NYIi9qEbFEUpCyikmnOYe4YlP8BMUdTcNCAquAKzu+FA7rZ1onj9x80mbnDdOW/K5bFf3Tv5kJplP33+gAbQ=="
 		},
 		"@types/md5": {
 			"version": "2.1.33",
@@ -69,26 +69,14 @@
 			"integrity": "sha512-/opXIbfn0P+VLt+N8DE4l8Mn8rbhiJgabU96ZJ0p9mxOkIks5gh6RUnpHak7Yh0SFkyjO/ODbxsQQPV2bpMmyA=="
 		},
 		"@types/request": {
-			"version": "2.48.2",
-			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.2.tgz",
-			"integrity": "sha512-gP+PSFXAXMrd5PcD7SqHeUjdGshAI8vKQ3+AvpQr3ht9iQea+59LOKvKITcQI+Lg+1EIkDP6AFSBUJPWG8GDyA==",
+			"version": "2.48.3",
+			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.3.tgz",
+			"integrity": "sha512-3Wo2jNYwqgXcIz/rrq18AdOZUQB8cQ34CXZo+LUwPJNpvRAL86+Kc2wwI8mqpz9Cr1V+enIox5v+WZhy/p3h8w==",
 			"requires": {
 				"@types/caseless": "*",
 				"@types/node": "*",
 				"@types/tough-cookie": "*",
 				"form-data": "^2.5.0"
-			},
-			"dependencies": {
-				"form-data": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.0.tgz",
-					"integrity": "sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==",
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.6",
-						"mime-types": "^2.1.12"
-					}
-				}
 			}
 		},
 		"@types/request-promise": {
@@ -768,6 +756,11 @@
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
 			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"dev": true
+		},
+		"bluebird": {
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
 		},
 		"bn.js": {
 			"version": "4.11.8",
@@ -1566,6 +1559,11 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
+		"ejs": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.1.tgz",
+			"integrity": "sha512-kS/gEPzZs3Y1rRsbGX4UOSjtP/CeJP0CxSNZHYxGfVM/VgLcv0ZqM7C45YyTj2DI2g7+P9Dd24C+IMIg6D0nYQ=="
+		},
 		"elliptic": {
 			"version": "6.4.1",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
@@ -2131,9 +2129,9 @@
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+			"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
@@ -4849,9 +4847,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.1.31",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+			"integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
 		},
 		"public-encrypt": {
 			"version": "4.0.3",
@@ -5108,6 +5106,18 @@
 				"tough-cookie": "~2.4.3",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"form-data": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+					"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.6",
+						"mime-types": "^2.1.12"
+					}
+				}
 			}
 		},
 		"request-promise": {
@@ -5119,13 +5129,6 @@
 				"request-promise-core": "1.1.2",
 				"stealthy-require": "^1.1.1",
 				"tough-cookie": "^2.3.3"
-			},
-			"dependencies": {
-				"bluebird": {
-					"version": "3.5.5",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-					"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
-				}
 			}
 		},
 		"request-promise-core": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "onCommand:quarkusTools.createMavenProject",
     "onCommand:quarkusTools.addExtension",
     "onCommand:quarkusTools.debugQuarkusProject",
+    "onCommand:quarkusTools.welcome",
     "onLanguage:quarkus-properties"
   ],
   "main": "./dist/extension",
@@ -69,6 +70,10 @@
       {
         "command": "quarkusTools.debugQuarkusProject",
         "title": "Quarkus: Debug current Quarkus project"
+      },
+      {
+        "command": "quarkusTools.welcome",
+        "title": "Quarkus: Welcome"
       }
     ],
     "snippets": [
@@ -105,6 +110,11 @@
           "default": "Ask",
           "description": "Determines whether to terminate the quarkus:dev task after closing the debug session.",
           "scope": "window"
+        },
+        "quarkus.tools.alwaysShowWelcomePage": {
+          "type": "boolean",
+          "default": "true",
+          "description": "Determines whether to show the welcome page on extension startup."
         },
         "quarkus.tools.starter.api": {
           "type": "string",
@@ -253,11 +263,12 @@
     "webpack-cli": "^3.3.2"
   },
   "dependencies": {
-    "@types/lodash": "^4.14.134",
-    "@types/request": "^2.48.2",
+    "@types/lodash": "^4.14.141",
+    "@types/request": "^2.48.3",
     "@types/request-promise": "^4.1.44",
     "@types/unzipper": "^0.9.2",
     "@types/yauzl": "^2.9.1",
+    "ejs": "^2.7.1",
     "expand-home-dir": "0.0.3",
     "find-java-home": "^1.0.0",
     "find-up": "^4.1.0",

--- a/src/QuarkusConfig.ts
+++ b/src/QuarkusConfig.ts
@@ -59,16 +59,24 @@ export namespace QuarkusConfig {
     return getQuarkusToolsSection<string[]>('starter.defaults.extensions', []);
   }
 
+  export function getAlwaysShowWelcomePage(): boolean {
+    return getQuarkusToolsSection<boolean>('alwaysShowWelcomePage', true);
+  }
+
   export function getTerminateProcessOnDebugExit(): TerminateProcessConfig {
     return getQuarkusToolsSection<TerminateProcessConfig>('debug.terminateProcessOnExit');
   }
 
-  export function saveDefaults(defaults: Defaults): void {
+  export function setDefaults(defaults: Defaults): void {
     workspace.getConfiguration(QUARKUS_CONFIG_NAME).update('starter.defaults', defaults, true);
   }
 
-  export function saveTerminateProcessOnDebugExit(save: string): void {
-    workspace.getConfiguration(QUARKUS_CONFIG_NAME).update('debug.terminateProcessOnExit', save, true);
+  export function setAlwaysShowWelcomePage(value: boolean): void {
+    workspace.getConfiguration(QUARKUS_CONFIG_NAME).update('alwaysShowWelcomePage', value, true);
+  }
+
+  export function setTerminateProcessOnDebugExit(value: string): void {
+    workspace.getConfiguration(QUARKUS_CONFIG_NAME).update('debug.terminateProcessOnExit', value, true);
   }
 
   function getQuarkusToolsSection<T>(section: string, fallback?: T): T|undefined {

--- a/src/debugging/terminateProcess.ts
+++ b/src/debugging/terminateProcess.ts
@@ -72,7 +72,7 @@ function saveToConfig(terminate: boolean, askAgain: boolean): void {
   } else if (!terminate) {
     save = TerminateProcessConfig.DontTerminate;
   }
-  QuarkusConfig.saveTerminateProcessOnDebugExit(save);
+  QuarkusConfig.setTerminateProcessOnDebugExit(save);
 }
 
 async function getUserInputTerminate(): Promise<boolean> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,8 @@ import { createTerminateDebugListener } from './debugging/terminateProcess';
 import { generateProjectWizard } from './generateProject/generationWizard';
 import { prepareExecutable } from './languageServer/javaServerStarter';
 import { tryStartDebugging } from './debugging/startDebugging';
+import { WelcomeWebview } from './webviews/WelcomeWebview';
+import { QuarkusConfig } from './QuarkusConfig';
 
 const disposables = [];
 let terminateDebugListener: Disposable;
@@ -46,6 +48,8 @@ interface QuarkusPropertyDefinitionParams {
 }
 
 export function activate(context: ExtensionContext) {
+
+  displayWelcomePageIfNeeded(context);
 
   terminateDebugListener = createTerminateDebugListener(disposables);
 
@@ -76,12 +80,17 @@ export function activate(context: ExtensionContext) {
   });
 
   registerVSCodeCommands(context);
-
 }
 
 export function deactivate() {
   terminateDebugListener.dispose();
   disposables.forEach(disposable => disposable.dispose());
+}
+
+function displayWelcomePageIfNeeded(context: ExtensionContext): void {
+  if (QuarkusConfig.getAlwaysShowWelcomePage()) {
+    WelcomeWebview.createOrShow(context);
+  }
 }
 
 function registerVSCodeCommands(context: ExtensionContext) {
@@ -105,6 +114,13 @@ function registerVSCodeCommands(context: ExtensionContext) {
    */
   context.subscriptions.push(commands.registerCommand('quarkusTools.debugQuarkusProject', () => {
     tryStartDebugging();
+  }));
+
+  /**
+   * Command for displaying welcome page
+   */
+  context.subscriptions.push(commands.registerCommand('quarkusTools.welcome', () => {
+    WelcomeWebview.createOrShow(context);
   }));
 }
 

--- a/src/generateProject/generationWizard.ts
+++ b/src/generateProject/generationWizard.ts
@@ -176,7 +176,7 @@ async function showOpenFolderDialog(customOptions: OpenDialogOptions): Promise<U
 }
 
 function saveDefaultsToConfig(state: ProjectGenState): void {
-  QuarkusConfig.saveDefaults({
+  QuarkusConfig.setDefaults({
     groupId: state.groupId,
     artifactId: state.artifactId,
     projectVersion: state.projectVersion,

--- a/src/webviews/WelcomeWebview.ts
+++ b/src/webviews/WelcomeWebview.ts
@@ -1,0 +1,134 @@
+import { ExtensionContext } from "vscode";
+
+/**
+ * Copyright 2019 Red Hat, Inc. and others.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as ejs from 'ejs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { QuarkusConfig } from "../QuarkusConfig";
+
+export class WelcomeWebview {
+
+  public static currentPanel: WelcomeWebview | undefined;
+
+  private readonly RESOURCE_FOLDER: string = 'webviews';
+  private _context: ExtensionContext;
+  private _panel: vscode.WebviewPanel;
+
+  public static createOrShow(context: ExtensionContext) {
+		const column = vscode.window.activeTextEditor
+			? vscode.window.activeTextEditor.viewColumn
+			: undefined;
+
+		// If we already have a panel, show it.
+		if (WelcomeWebview.currentPanel) {
+			WelcomeWebview.currentPanel._panel.reveal(column);
+			return;
+		}
+
+		WelcomeWebview.currentPanel = new WelcomeWebview(context);
+	}
+
+  private constructor(context: ExtensionContext) {
+    this._context = context;
+    this._panel = this.createPanel();
+    this.setPanelHtml();
+    this.setCheckboxListener();
+  }
+
+  private createPanel(): vscode.WebviewPanel {
+    return vscode.window.createWebviewPanel(
+      'welcome', // Identifies the type of the webview. Used internally
+      'Quarkus Tools for Visual Studio Code', // Title of the panel displayed to the user
+      { viewColumn: vscode.ViewColumn.One, preserveFocus: false }, // Editor column to show the new webview panel in.
+      {
+        enableCommandUris: true,
+        enableScripts: true,
+        localResourceRoots: [vscode.Uri.file(path.join(this._context.extensionPath, this.RESOURCE_FOLDER))]
+      }
+    );
+  }
+
+  private async setPanelHtml(): Promise<void> {
+    this._panel.webview.html = await this.getWebviewContent();
+  }
+
+  private async getWebviewContent(): Promise<string> {
+
+    const htmlTemplatePath: string = this.getHtmlTemplateUri().fsPath;
+
+    const data = {
+      checkboxValue: QuarkusConfig.getAlwaysShowWelcomePage(),
+      cssUri: this.getCssUri(),
+      cspSource: this._panel.webview.cspSource,
+      jsUri: this.getJsUri(),
+    };
+
+    return await new Promise((resolve: any, reject: any): any => {
+      ejs.renderFile(htmlTemplatePath, data, { async: true }, (error: any, data: string) => {
+          if (error) {
+              reject(error);
+          } else {
+              resolve(data);
+          }
+      });
+    });
+  }
+
+  private getCssUri(): vscode.Uri {
+    const css: vscode.Uri = vscode.Uri.file(
+      path.join(this._context.extensionPath, this.RESOURCE_FOLDER, 'styles', 'welcome.css')
+    );
+
+    return this._panel.webview.asWebviewUri(css);
+  }
+
+  private getJsUri(): vscode.Uri {
+    const css: vscode.Uri = vscode.Uri.file(
+      path.join(this._context.extensionPath, this.RESOURCE_FOLDER, 'scripts', 'welcome.js')
+    );
+
+    return this._panel.webview.asWebviewUri(css);
+  }
+
+  private getHtmlTemplateUri(): vscode.Uri {
+    return vscode.Uri.file(
+      path.join(this._context.extensionPath, this.RESOURCE_FOLDER, 'templates', 'welcome.ejs')
+    );
+  }
+
+  private getNonce(): string {
+    let text: string = '';
+    const possible: string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    for (let i = 0; i < 32; i++) {
+      text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+  }
+
+  private setCheckboxListener() {
+    this._panel.webview.onDidReceiveMessage(
+      message => {
+        if (message.command === 'checkbox-changed') {
+          const checkboxValue: boolean = message.newValue;
+          QuarkusConfig.setAlwaysShowWelcomePage(checkboxValue);
+        }
+      },
+      undefined,
+      this._context.subscriptions
+    );
+  }
+}

--- a/webviews/scripts/welcome.js
+++ b/webviews/scripts/welcome.js
@@ -1,0 +1,13 @@
+const vscode = acquireVsCodeApi();
+
+document.addEventListener("DOMContentLoaded", function(event) {
+
+  const checkbox = document.getElementById('showWhenUsingQuarkusTools');
+
+  checkbox.addEventListener('click', () => {
+    vscode.postMessage({
+      command: 'checkbox-changed',
+      newValue: checkbox.checked
+    })
+  });
+});

--- a/webviews/styles/button.css
+++ b/webviews/styles/button.css
@@ -1,0 +1,26 @@
+/* https://css-tricks.com/overriding-default-button-styles/ */
+
+button {
+    display: inline-block;
+    border: none;
+    padding: 12px 16px;
+    margin: 0;
+    text-decoration: none;
+    background: var(--vscode-button-background);
+    color: #ffffff;
+    font-family: sans-serif;
+    font-size: 14px;
+    cursor: pointer;
+    text-align: center;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+}
+
+button:hover,
+button:focus {
+    background: var(--vscode-button-hoverBackground);
+}
+button:focus {
+    outline: 1px solid var(--vscode-button-hoverBackground);
+    /* outline-offset: -4px; */
+}

--- a/webviews/styles/column.css
+++ b/webviews/styles/column.css
@@ -1,0 +1,12 @@
+/* https://www.w3schools.cm/howto/howto_css_two_columns.asp */
+
+.column {
+  float: left;
+  width: 35%;
+}
+
+.row {
+  display: flex;
+  clear: both;
+  float: none;
+}

--- a/webviews/styles/welcome.css
+++ b/webviews/styles/welcome.css
@@ -1,0 +1,34 @@
+@import url("button.css");
+@import url("column.css");
+
+h2 {
+  font-weight: 400;
+}
+
+.title-header {
+  font-size: 26px;
+  margin-bottom: 12px;
+}
+
+.no-bottom-margin {
+  margin-bottom: 0px;
+}
+
+.section-title {
+  margin-bottom: 0px;
+  font-size: 18px;
+}
+
+.section-div {
+  padding: 3px 25px;
+}
+
+.section-link {
+  display: block;
+  margin: 0;
+}
+
+#showWhenUsingQuarkusTools {
+  vertical-align: middle;
+  margin-left: 0px;
+}

--- a/webviews/templates/welcome.ejs
+++ b/webviews/templates/welcome.ejs
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src <%= cspSource %>; script-src <%= cspSource %>">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="<%= cssUri %>">
+  <title>Welcome</title>
+</head>
+
+<body>
+  <div class="section-div">
+    <h2 class="title-header">Quarkus Tools for Visual Studio Code</h2>
+    <p class="no-bottom-margin">Welcome! This extension provides tools to get you up and running with Quarkus application development in Visual
+      Studio
+      Code.</p>
+  </div>
+
+  <div class="section-div">
+    <h2 class="section-title">Requirements</h2>
+    <p>The <a href="vscode:extension/vscjava.vscode-java-pack">Java Extension Pack</a> is highly recommended.</p>
+    <ul class="no-bottom-margin">
+      <li>Java JDK (or JRE) 8 or more recent</li>
+      <li><a href="vscode:extension/redhat.java">Language Support for Java(TM) by Red Hat</a></li>
+      <li><a href="vscode:extension/vscjava.vscode-java-debug">Debugger for Java</a></li>
+    </ul>
+  </div>
+
+  <div class="section-div">
+    <h2 class="section-title">Get started</h2>
+    <p>Create a new Maven based Quarkus project or open an existing Quarkus project to get started.</p>
+    <a href="command:quarkusTools.createMavenProject"><button>Create Quarkus project</button></a>
+  </div>
+
+  <div class="row">
+    <div class="column">
+      <div class="section-div">
+        <h2 class="section-title">New to Quarkus?</h2>
+        <p>Refer to the Quarkus Getting Started guide. The guide provides instructions from starting your first project,
+          to creating a native executable.
+        </p>
+        <a class="section-link" href="https://quarkus.io/get-started/">View Getting Started guide</a>
+      </div>
+    </div>
+    <div class="column">
+      <div class="section-div">
+          <h2 class="section-title">Documentation</h2>
+          <p>The Quarkus guides from quarkus.io/guides provides detailed documentation and tutorials for different use
+            cases.</p>
+          <a class="section-link" href="https://quarkus.io/guides/">View guides</a>
+          <a class="section-link" href="https://lordofthejars.github.io/quarkus-cheat-sheet/">View Quarkus Cheet-Sheet</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="column">
+      <div class="section-div">
+        <h2 class="section-title">Getting help</h2>
+        <p>Keep in touch with the Quarkus community; there are many ways to reach out.</p>
+        <a class="section-link" href="https://quarkus.io/community/">View community links</a>
+      </div>
+    </div>
+    <div class="column">
+      <div class="section-div">
+        <h2 class="section-title">Sample projects</h2>
+        <p>Explore a wide variety of Quarkus quickstart projects, each focusing on a different aspect of Quarkus
+          application development.</p>
+        <a class="section-link" href="https://github.com/quarkusio/quarkus-quickstarts">View quickstart projects</a>
+      </div>
+    </div>
+  </div>
+  <div class="section-div">
+    <input type="checkbox" id="showWhenUsingQuarkusTools" <% if (checkboxValue) { %> checked <% } %>>
+    <label for="showWhenUsingQuarkusTools">Show welcome page when using Quarkus Tools</label>
+  </div>
+</body>
+<script src="<%= jsUri %>"></script>
+</html>


### PR DESCRIPTION
For #53 

WELCOME.md contains my suggestions for a welcome page.

For the "View quickstart projects" link, I think it would be nice if it could link to a new VSCode webview presenting the projects, similar to how the [IBM Blockchain Platform VS Code extension](https://marketplace.visualstudio.com/items?itemName=IBMBlockchain.ibm-blockchain-platform) has their welcome page link to separate VSCode webviews. The new webview would show the list of projects and also would reference the [original quickstarts github repository](https://github.com/quarkusio/quarkus-quickstarts).

Same with the "View guides" link, I think it would be nice if it would open a new webview containing the guides, and also reference the source of all guides: https://quarkus.io/guides/.

I'm not sure if having new webviews is entirely necessary though. I think it would just look neat/organized.

Signed-off-by: David Kwon <dakwon@redhat.com>