### PR TITLE
Add requried Quarkus properties validation setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The following settings are supported:
 * `quarkus.tools.validation.enabled` : Enables Quarkus validation. Default is `true`.
 * `quarkus.tools.validation.duplicate.severity` : Validation severity for duplicate Quarkus properties.
 Default is `warning`.
+* `quarkus.tools.validation.required.severity` : Validation severity for required Quarkus properties.
+Default is `none`.
 * `quarkus.tools.validation.syntax.severity` : Validation severity for Quarkus property syntax checking.
 Default is `error`.
 * `quarkus.tools.validation.unknown.severity` : Validation severity for unknown Quarkus properties. Default is `warning`.

--- a/package.json
+++ b/package.json
@@ -180,6 +180,17 @@
           "description": "Validation severity for duplicate Quarkus properties.",
           "scope": "window"
         },
+        "quarkus.tools.validation.required.severity": {
+          "type": "string",
+          "enum": [
+            "none",
+            "warning",
+            "error"
+          ],
+          "default": "none",
+          "description": "Validation severity for required Quarkus properties.",
+          "scope": "window"
+        },
         "quarkus.tools.validation.unknown.severity": {
           "type": "string",
           "enum": [


### PR DESCRIPTION
This PR compliments https://github.com/redhat-developer/quarkus-ls/pull/91 to set the required properties validation setting.

Signed-off-by: David Kwon <dakwon@redhat.com>