### PR TITLE
Add tests that check if extension activates when a `quarkus.tools` command is called

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,10 +24,10 @@
 			"runtimeExecutable": "${execPath}",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
-				"--extensionTestsPath=${workspaceFolder}/out/test"
+				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
 			],
 			"outFiles": [
-				"${workspaceFolder}/dist/**/*.js"
+				"${workspaceFolder}/out/test/**/*.js"
 			],
 			"preLaunchTask": "npm: watch"
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,12 @@
 			"resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
 			"integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
 		},
+		"@types/chai": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.3.tgz",
+			"integrity": "sha512-VRw2xEGbll3ZiTQ4J02/hUjNqZoue1bMhoo2dgM2LXjDdyaq4q80HgBDHwpI0/VKlo4Eg+BavyQMv/NYgTetzA==",
+			"dev": true
+		},
 		"@types/fs-extra": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-7.0.0.tgz",
@@ -600,6 +606,12 @@
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
+		"assertion-error": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true
+		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -993,6 +1005,20 @@
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
+		"chai": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+			"integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+			"dev": true,
+			"requires": {
+				"assertion-error": "^1.1.0",
+				"check-error": "^1.0.2",
+				"deep-eql": "^3.0.1",
+				"get-func-name": "^2.0.0",
+				"pathval": "^1.1.0",
+				"type-detect": "^4.0.5"
+			}
+		},
 		"chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -1008,6 +1034,12 @@
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
 			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+		},
+		"check-error": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"dev": true
 		},
 		"chokidar": {
 			"version": "2.1.6",
@@ -1399,6 +1431,15 @@
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
+		},
+		"deep-eql": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"dev": true,
+			"requires": {
+				"type-detect": "^4.0.0"
+			}
 		},
 		"default-compare": {
 			"version": "1.0.0",
@@ -2744,6 +2785,12 @@
 			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
 			"dev": true
 		},
+		"get-func-name": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"dev": true
+		},
 		"get-stream": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -3196,9 +3243,9 @@
 			"dev": true
 		},
 		"https-proxy-agent": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-			"integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+			"version": "2.2.4",
+			"resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
 			"dev": true,
 			"requires": {
 				"agent-base": "^4.3.0",
@@ -4700,6 +4747,12 @@
 				}
 			}
 		},
+		"pathval": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+			"dev": true
+		},
 		"pbkdf2": {
 			"version": "3.0.17",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -6023,6 +6076,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
 			"integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
+			"dev": true
+		},
+		"type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true
 		},
 		"typedarray": {

--- a/package.json
+++ b/package.json
@@ -292,7 +292,6 @@
     "fs-extra": "^8.0.1",
     "glob": "^7.1.4",
     "md5": "^2.2.1",
-    "path-exists": "^4.0.0",
     "request": "^2.88.0",
     "request-promise": "^4.2.4",
     "user-home": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -261,6 +261,7 @@
     "build-ext": "./node_modules/.bin/gulp buildExtension"
   },
   "devDependencies": {
+    "@types/chai": "^4.2.3",
     "@types/fs-extra": "^7.0.0",
     "@types/md5": "^2.1.33",
     "@types/mocha": "^5.2.6",
@@ -268,6 +269,7 @@
     "@types/vscode": "^1.37.0",
     "@types/which": "^1.3.1",
     "@types/xml2js": "^0.4.4",
+    "chai": "^4.2.0",
     "gulp": "^4.0.2",
     "gulp-rename": "^1.4.0",
     "mocha": "^6.2.1",

--- a/src/QuarkusConfig.ts
+++ b/src/QuarkusConfig.ts
@@ -20,7 +20,7 @@ import {
   DEFAULT_PROJECT_VERSION,
   DEFAULT_PACKAGE_NAME,
   DEFAULT_RESOURCE_NAME
-} from './definitions/wizardConstants';
+} from './definitions/constants';
 import { workspace } from 'vscode';
 
 /**

--- a/src/definitions/QExtension.ts
+++ b/src/definitions/QExtension.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { QUARKUS_GROUP_ID } from './wizardConstants';
+import { QUARKUS_GROUP_ID } from './constants';
 
 /**
 * Interface representing a Quarkus extension

--- a/src/definitions/constants.ts
+++ b/src/definitions/constants.ts
@@ -15,12 +15,23 @@
  */
 
 // Quarkus language server request and notifications
-export const QUARKUS_PROJECT_REQUEST = 'quarkus/projectInfo';
-export const QUARKUS_PROPERTY_DEFINITION_REQUEST = 'quarkus/propertyDefinition';
+export namespace QuarkusLS {
+  export const PROJECT_REQUEST = 'quarkus/projectInfo';
+  export const PROPERTY_DEFINITION_REQUEST = 'quarkus/propertyDefinition';
+}
 
-// Quarkus jdt.ls extension commands
-export const JDTLS_PROJECT_INFO_COMMAND = 'quarkus.java.projectInfo';
-export const JDTLS_PROPERTY_DEFINITION_COMMAND = 'quarkus.java.propertyDefinition';
+export namespace JdtLSCommands {
+  export const PROJECT_INFO_COMMAND = 'quarkus.java.projectInfo';
+  export const PROPERTY_DEFINITION_COMMAND = 'quarkus.java.propertyDefinition';
+}
+
+// VSCode Quarkus Tools commands
+export namespace VSCodeCommands {
+  export const CREATE_PROJECT = 'quarkusTools.createProject';
+  export const ADD_EXTENSIONS = 'quarkusTools.addExtension';
+  export const DEBUG_QUARKUS_PROJECT = 'quarkusTools.debugQuarkusProject';
+  export const QUARKUS_WELCOME = 'quarkusTools.welcome';
+}
 
 // Constants related to project generation
 export const DEFAULT_API_URL: string = 'https://code.quarkus.io/api';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@
  */
 import * as requirements from './languageServer/requirements';
 
-import { QUARKUS_PROJECT_REQUEST, JDTLS_PROJECT_INFO_COMMAND, QUARKUS_PROPERTY_DEFINITION_REQUEST, JDTLS_PROPERTY_DEFINITION_COMMAND } from './definitions/wizardConstants';
+import { JdtLSCommands, QuarkusLS, VSCodeCommands } from './definitions/constants';
 
 import { DidChangeConfigurationNotification, Disposable, LanguageClientOptions, LanguageClient, RequestType } from 'vscode-languageclient';
 import { ExtensionContext, commands, window, workspace } from 'vscode';
@@ -54,14 +54,14 @@ export function activate(context: ExtensionContext) {
   terminateDebugListener = createTerminateDebugListener(disposables);
 
   connectToLS().then(() => {
-    const quarkusPojectInfoRequest = new RequestType<QuarkusProjectInfoParams, any, void, void>(QUARKUS_PROJECT_REQUEST);
+    const quarkusPojectInfoRequest = new RequestType<QuarkusProjectInfoParams, any, void, void>(QuarkusLS.PROJECT_REQUEST);
     languageClient.onRequest(quarkusPojectInfoRequest, async (params: QuarkusProjectInfoParams) =>
-       <any> await commands.executeCommand("java.execute.workspaceCommand", JDTLS_PROJECT_INFO_COMMAND, params)
+       <any> await commands.executeCommand("java.execute.workspaceCommand", JdtLSCommands.PROJECT_INFO_COMMAND, params)
     );
 
-	const quarkusPropertyDefinitionRequest = new RequestType<QuarkusPropertyDefinitionParams, any, void, void>(QUARKUS_PROPERTY_DEFINITION_REQUEST);
+	const quarkusPropertyDefinitionRequest = new RequestType<QuarkusPropertyDefinitionParams, any, void, void>(QuarkusLS.PROPERTY_DEFINITION_REQUEST);
     languageClient.onRequest(quarkusPropertyDefinitionRequest, async (params: QuarkusPropertyDefinitionParams) =>
-       <any> await commands.executeCommand("java.execute.workspaceCommand", JDTLS_PROPERTY_DEFINITION_COMMAND, params)
+       <any> await commands.executeCommand("java.execute.workspaceCommand", JdtLSCommands.PROPERTY_DEFINITION_COMMAND, params)
     );
 
     /**
@@ -98,28 +98,28 @@ function registerVSCodeCommands(context: ExtensionContext) {
   /**
    * Command for creating a Quarkus Maven project
    */
-  context.subscriptions.push(commands.registerCommand('quarkusTools.createProject', () => {
+  context.subscriptions.push(commands.registerCommand(VSCodeCommands.CREATE_PROJECT, () => {
     generateProjectWizard();
   }));
 
   /**
    * Command for adding Quarkus extensions to current Quarkus Maven project
    */
-  context.subscriptions.push(commands.registerCommand('quarkusTools.addExtension', () => {
+  context.subscriptions.push(commands.registerCommand(VSCodeCommands.ADD_EXTENSIONS, () => {
     addExtensionsWizard();
   }));
 
   /**
    * Command for debugging current Quarkus Maven project
    */
-  context.subscriptions.push(commands.registerCommand('quarkusTools.debugQuarkusProject', () => {
+  context.subscriptions.push(commands.registerCommand(VSCodeCommands.DEBUG_QUARKUS_PROJECT, () => {
     tryStartDebugging();
   }));
 
   /**
    * Command for displaying welcome page
    */
-  context.subscriptions.push(commands.registerCommand('quarkusTools.welcome', () => {
+  context.subscriptions.push(commands.registerCommand(VSCodeCommands.QUARKUS_WELCOME, () => {
     WelcomeWebview.createOrShow(context);
   }));
 }

--- a/src/generateProject/generationWizard.ts
+++ b/src/generateProject/generationWizard.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as fse from 'fs-extra';
 
-import { INPUT_TITLE } from '../definitions/wizardConstants';
+import { INPUT_TITLE } from '../definitions/constants';
 import { QuarkusConfig } from '../QuarkusConfig';
 import { MultiStepInput } from '../utils/multiStepUtils';
 import { OpenDialogOptions, Uri, commands, window } from 'vscode';

--- a/src/generateProject/pickExtensions.ts
+++ b/src/generateProject/pickExtensions.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { QUARKUS_GROUP_ID } from '../definitions/wizardConstants';
+import { QUARKUS_GROUP_ID } from '../definitions/constants';
 import { QuarkusConfig } from '../QuarkusConfig';
 import { MultiStepInput } from '../utils/multiStepUtils';
 import { QExtension } from '../definitions/QExtension';

--- a/src/languageServer/requirements.ts
+++ b/src/languageServer/requirements.ts
@@ -3,8 +3,8 @@
 import { workspace, Uri } from 'vscode';
 import * as cp from 'child_process';
 import * as path from 'path';
+import * as fs from 'fs';
 
-const pathExists = require('path-exists');
 const expandHomeDir = require('expand-home-dir');
 const findJavaHome = require('find-java-home');
 const isWindows = process.platform.indexOf('win') === 0;
@@ -47,9 +47,9 @@ function checkJavaRuntime(): Promise<string> {
 
         if (javaHome) {
             javaHome = expandHomeDir(javaHome);
-            if (!pathExists.sync(javaHome)) {
+            if (!fs.existsSync(javaHome)) {
                 openJDKDownload(reject, source+' points to a missing folder');
-            } else if (!pathExists.sync(path.resolve(javaHome as string, 'bin', JAVA_FILENAME))) {
+            } else if (!fs.existsSync(path.resolve(javaHome as string, 'bin', JAVA_FILENAME))) {
                 openJDKDownload(reject, source+ ' does not point to a Java runtime.');
             }
             return resolve(javaHome);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,18 +1,32 @@
-import * as assert from 'assert';
-import { before } from 'mocha';
-
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
 import * as vscode from 'vscode';
-// import * as myExtension from '../extension';
 
-suite('Extension Test Suite', () => {
-	before(() => {
-		vscode.window.showInformationMessage('Start all tests.');
-	});
+import { VSCodeCommands } from '../../definitions/constants';
 
-	test('Sample test', () => {
-		assert.equal(-1, [1, 2, 3].indexOf(5));
-		assert.equal(-1, [1, 2, 3].indexOf(0));
-	});
+import { expect } from 'chai';
+import { before, describe, it } from 'mocha';
+
+describe('VS Code extension tests', () => {
+
+  const QUARKUS_COMMANDS: string[] = [
+    VSCodeCommands.ADD_EXTENSIONS,
+    VSCodeCommands.CREATE_PROJECT,
+    VSCodeCommands.DEBUG_QUARKUS_PROJECT,
+    VSCodeCommands.QUARKUS_WELCOME
+  ];
+
+  before(() => {
+    vscode.window.showInformationMessage('Start all tests.');
+  });
+
+  it('should be present', () => {
+    expect(vscode.extensions.getExtension('redhat.vscode-quarkus')).to.be.ok;
+  });
+
+  it('should have Quarkus commands as activation events', () => {
+    const packageJSON = vscode.extensions.getExtension('redhat.vscode-quarkus').packageJSON;
+
+    QUARKUS_COMMANDS.forEach((command: string) => {
+      expect(packageJSON.activationEvents).to.include(`onCommand:${command}`, `The ${command} command is not registered as an activation event in package.json`);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #64 (without the application.properties activation test)

This PR has two commits because, In addition to adding tests, I have a commit that removes [path-exists](https://www.npmjs.com/package/path-exists) as a dependency.

Previously, path-exists was used for the `path-exists.sync()` function. This PR removes path-exists and uses `fs.existsSync()`, since it has been undeprecated in Node.js since 6.8.0, vscode-quarkus uses version 10.11.0.

I also had an additional test to check that the quarkus commands would correctly register once the extension activates. This test is not in this PR, but maybe it can be added in the future:
```
 // manually activate vscode-quarkus
 it('should activate', () => {
   return vscode.extensions.getExtension('redhat.vscode-quarkus').activate();
 }).timeout(1 * 60 * 1000);

 // check if all quarkus commands are registered
 it('should register all Quarkus commands', () => {
   return vscode.commands.getCommands(true).then((commands) => {
     const foundQuarkusCommands = commands.filter((value) => {
       return QUARKUS_COMMANDS.indexOf(value) >= 0 || value.startsWith('quarkusTools.');
     });
     expect(foundQuarkusCommands.length).to.equal(QUARKUS_COMMANDS.length, 'Some Quarkus commands are not registered properly or a new command is not added to the test');
   });
 });
```