### PR TITLE
Welcome page checkbox update

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
         },
         "quarkus.tools.alwaysShowWelcomePage": {
           "type": "boolean",
-          "default": "true",
+          "default": true,
           "description": "Determines whether to show the welcome page on extension startup."
         },
         "quarkus.tools.starter.api": {
@@ -169,19 +169,19 @@
         },
         "quarkus.tools.formatting.surroundEqualsWithSpaces": {
           "type": "boolean",
-          "default": "false",
+          "default": false,
           "description": "Insert spaces around the equals sign when formatting the application.properties file",
           "scope": "window"
         },
         "quarkus.tools.symbols.showAsTree": {
           "type": "boolean",
-          "default": "true",
+          "default": true,
           "description": "Show Quarkus properties as tree.",
           "scope": "window"
         },
         "quarkus.tools.validation.enabled": {
           "type": "boolean",
-          "default": "true",
+          "default": true,
           "description": "Enables Quarkus validation",
           "scope": "window"
         },

--- a/src/QuarkusConfig.ts
+++ b/src/QuarkusConfig.ts
@@ -27,44 +27,54 @@ import { workspace } from 'vscode';
  * This class manages the extension's interaction with
  * settings.json
  */
-const QUARKUS_CONFIG_NAME = 'quarkus.tools';
-
 export namespace QuarkusConfig {
 
+  export const QUARKUS_CONFIG_NAME = 'quarkus.tools';
+
+  export const STARTER_API = 'quarkus.tools.starter.api';
+  export const GROUP_ID = 'quarkus.tools.starter.defaults.groupId';
+  export const ARTIFACT_ID = 'quarkus.tools.starter.defaults.artifactId';
+  export const PROJECT_VERSION = 'quarkus.tools.starter.defaults.projectVersion';
+  export const PACKAGE_NAME = 'quarkus.tools.starter.defaults.packageName';
+  export const RESOURCE_NAME = 'quarkus.tools.starter.defaults.resourceName';
+  export const EXTENSIONS = 'quarkus.tools.starter.defaults.extensions';
+  export const ALWAYS_SHOW_WELCOME_PAGE = 'quarkus.tools.alwaysShowWelcomePage';
+  export const DEBUG_TERMINATE_ON_EXIT = 'quarkus.tools.debug.terminateProcessOnExit';
+
   export function getApiUrl(): string {
-    return getQuarkusToolsSection<string>('starter.api', DEFAULT_API_URL);
+    return workspace.getConfiguration().get<string>(STARTER_API, DEFAULT_API_URL);
   }
 
   export function getDefaultGroupId(): string {
-    return getQuarkusToolsSection<string>('starter.defaults.groupId', DEFAULT_GROUP_ID);
+    return workspace.getConfiguration().get<string>(GROUP_ID, DEFAULT_GROUP_ID);
   }
 
   export function getDefaultArtifactId(): string {
-    return getQuarkusToolsSection<string>('starter.defaults.artifactId', DEFAULT_ARTIFACT_ID);
+    return workspace.getConfiguration().get<string>(ARTIFACT_ID, DEFAULT_ARTIFACT_ID);
   }
 
   export function getDefaultProjectVersion(): string {
-    return getQuarkusToolsSection<string>('starter.defaults.projectVersion', DEFAULT_PROJECT_VERSION);
+    return workspace.getConfiguration().get<string>(PROJECT_VERSION, DEFAULT_PROJECT_VERSION);
   }
 
   export function getDefaultPackageName(): string {
-    return getQuarkusToolsSection<string>('starter.defaults.packageName', DEFAULT_PACKAGE_NAME);
+    return workspace.getConfiguration().get<string>(PACKAGE_NAME, DEFAULT_PACKAGE_NAME);
   }
 
   export function getDefaultResourceName(): string {
-    return getQuarkusToolsSection<string>('starter.defaults.resourceName', DEFAULT_RESOURCE_NAME);
+    return workspace.getConfiguration().get<string>(RESOURCE_NAME, DEFAULT_RESOURCE_NAME);
   }
 
   export function getDefaultExtensions(): any[] {
-    return getQuarkusToolsSection<string[]>('starter.defaults.extensions', []);
+    return workspace.getConfiguration().get<string[]>(EXTENSIONS, []);
   }
 
   export function getAlwaysShowWelcomePage(): boolean {
-    return getQuarkusToolsSection<boolean>('alwaysShowWelcomePage', true);
+    return workspace.getConfiguration().get<boolean>(ALWAYS_SHOW_WELCOME_PAGE, true);
   }
 
   export function getTerminateProcessOnDebugExit(): TerminateProcessConfig {
-    return getQuarkusToolsSection<TerminateProcessConfig>('debug.terminateProcessOnExit');
+    return workspace.getConfiguration().get<TerminateProcessConfig>(DEBUG_TERMINATE_ON_EXIT);
   }
 
   export function setDefaults(defaults: Defaults): void {
@@ -72,15 +82,15 @@ export namespace QuarkusConfig {
   }
 
   export function setAlwaysShowWelcomePage(value: boolean): void {
-    workspace.getConfiguration(QUARKUS_CONFIG_NAME).update('alwaysShowWelcomePage', value, true);
+    workspace.getConfiguration(QUARKUS_CONFIG_NAME).update(removeQuarkusConfigName(ALWAYS_SHOW_WELCOME_PAGE), value, true);
   }
 
   export function setTerminateProcessOnDebugExit(value: string): void {
-    workspace.getConfiguration(QUARKUS_CONFIG_NAME).update('debug.terminateProcessOnExit', value, true);
+    workspace.getConfiguration(QUARKUS_CONFIG_NAME).update(removeQuarkusConfigName(DEBUG_TERMINATE_ON_EXIT), value, true);
   }
 
-  function getQuarkusToolsSection<T>(section: string, fallback?: T): T|undefined {
-    return workspace.getConfiguration(QUARKUS_CONFIG_NAME).get<T>(section, fallback);
+  function removeQuarkusConfigName(configName: string) {
+    return configName.replace(QUARKUS_CONFIG_NAME + '.', '');
   }
 }
 

--- a/src/webviews/WelcomeWebview.ts
+++ b/src/webviews/WelcomeWebview.ts
@@ -47,6 +47,7 @@ export class WelcomeWebview {
     this._panel = this.createPanel();
     this.setPanelHtml();
     this.setCheckboxListener();
+    this.setConfigListener();
   }
 
   private createPanel(): vscode.WebviewPanel {
@@ -112,15 +113,6 @@ export class WelcomeWebview {
     );
   }
 
-  private getNonce(): string {
-    let text: string = '';
-    const possible: string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    for (let i = 0; i < 32; i++) {
-      text += possible.charAt(Math.floor(Math.random() * possible.length));
-    }
-    return text;
-  }
-
   private setCheckboxListener() {
     this._panel.webview.onDidReceiveMessage(
       message => {
@@ -132,6 +124,14 @@ export class WelcomeWebview {
       undefined,
       this._context.subscriptions
     );
+  }
+
+  private setConfigListener() {
+    vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
+      if (event.affectsConfiguration('quarkus.tools.alwaysShowWelcomePage')) {
+        this.setPanelHtml();
+      }
+    });
   }
 
   private dispose() {


### PR DESCRIPTION
If the user changes the "Always Show Welcome Page" setting from VSCode settings while the welcome page is open, the welcome page will not update its checkbox. This gif shows the issue:
![Checkbox not updating](https://raw.githubusercontent.com/xorye/gifs/master/new_issues/welcome_checkbox.gif?token=AE3CR5J5VRLXDCHU6OS7NLK5V4Z3I)
When the checkbox is unchecked in the settings, the checkbox remains checked in the welcome page.

This PR fixes this issue.
This PR also does some slight refactoring for QuarkusConfig.ts, which is why there are two commits.