### PR TITLE
Validate initial input value, offers context on what is wrong

### DIFF
--- a/src/generateProject/validateInput.ts
+++ b/src/generateProject/validateInput.ts
@@ -14,48 +14,60 @@
 // For validation functions, return error message if there is an error
 // return undefined otherwise
 
-export async function validateGroupId(userInput: string): Promise<string|undefined> {
+export async function validateGroupId(userInput: string): Promise<string | undefined> {
   // regex referenced from
   // https://github.com/quarkusio/code.quarkus.io/blob/master/src/main/frontend/src/code-quarkus/pickers/info-picker.tsx
   const re = new RegExp('^([a-zA-Z_$][a-zA-Z\\d_$]*\\.)*[a-zA-Z_$][a-zA-Z\\d_$]*$');
   if (!re.test(userInput)) {
-    return 'Invalid groupId';
+    if (!/^[a-zA-Z_$]/.test(userInput)) {
+      return 'Invalid groupId: A valid groupId must start with a character from A to z, or one of the following symbols: _$';
+    } else if (!/[a-zA-Z\\d_$]$/.test(userInput)) {
+      return 'Invalid groupId: A valid groupId must end with a character from A to z, a number, or one of the following symbols: _$';
+    }
+    return 'Invalid groupId: A valid groupId can only contain characters from A to z, and the following symbols: ._$';
   }
   return undefined;
 }
 
-export async function validateArtifactId(userInput: string): Promise<string|undefined> {
+export async function validateArtifactId(userInput: string): Promise<string | undefined> {
   // regex referenced from
   // https://github.com/quarkusio/code.quarkus.io/blob/master/src/main/frontend/src/code-quarkus/pickers/info-picker.tsx
   const re = new RegExp('^[a-z][a-z0-9-._]*$');
   if (!re.test(userInput)) {
-    return 'Invalid artifactId';
+    if (!/^[a-z]/.test(userInput)) {
+      return 'Invalid artifactId: A valid artifactId must start with a character from a-z';
+    }
+    return 'Invalid artifactId: A valid artifactId can only contain characters from a-z, numbers, and the following symbols: -._';
   }
   return undefined;
 }
 
-export async function validateVersion(userInput: string): Promise<string|undefined> {
-  const re = new RegExp('[A-Za-z0-9_\\-.]+$');
-  if (!re.test(userInput)) {
-    return 'Invalid project version';
-  }
+export async function validateVersion(userInput: string): Promise<string | undefined> {
   return undefined;
 }
 
-export async function validatePackageName(userInput: string): Promise<string|undefined> {
+export async function validatePackageName(userInput: string): Promise<string | undefined> {
   // regex referenced from
   // https://github.com/quarkusio/code.quarkus.io/blob/master/src/main/frontend/src/code-quarkus/pickers/info-picker.tsx
   const re = new RegExp('^([a-zA-Z_$][a-zA-Z\\d_$]*\\.)*[a-zA-Z_$][a-zA-Z\\d_$]*$');
   if (!re.test(userInput)) {
-    return 'Invalid package name';
+    if (!/^[a-zA-Z_$]/.test(userInput)) {
+      return 'Invalid package name: A valid package name must start with a character from A to z, or one of the following symbols: _$';
+    } else if (!/[a-zA-Z\\d_$]$/.test(userInput)) {
+      return 'Invalid package name: A valid package name must end with characters from A to z, a number, or the following symbols: _$';
+    }
+    return 'Invalid package name: A valid package name can only contain characters from A to z and the following symbols: ._$';
   }
   return undefined;
 }
 
-export async function validateResourceName(userInput: string): Promise<string|undefined> {
-  const re = new RegExp('^[A-Za-z]+[A-Za-z0-9_.]*$');
+export async function validateResourceName(userInput: string): Promise<string | undefined> {
+  const re = new RegExp('^[A-Za-z]+[A-Za-z0-9_]*$');
   if (!re.test(userInput)) {
-    return 'Invalid resource name';
+    if (!/^[A-Za-z]/.test(userInput)) {
+      return 'Invalid resource name: A valid resource name must start with a character from A to z';
+    }
+    return 'Invalid resource name: A valid resource name can only contain characters from A to z, numbers, and underscores';
   }
   return undefined;
 }


### PR DESCRIPTION
Fixes #84

The create project wizard will now validate the default value injected in the field:
![validation gif](https://raw.githubusercontent.com/xorye/gifs/master/new_issues/validate_inital.gif?token=AE3CR5N2F5EUJIVBBY5GEQ25V5YK4)

The error messages for invalid groupId, artifactId, package name etc. now provide context:
![image](https://user-images.githubusercontent.com/20326645/66870298-1e48b300-ef6f-11e9-8fe4-5fc7250f938a.png)
![image](https://user-images.githubusercontent.com/20326645/66870308-27398480-ef6f-11e9-935e-d6b5ab60d6d2.png)

Also, I've noticed that there doesn't seem to be version validation for https://code.quarkus.io/. Is version something that should be validated for Maven projects in general?

Before, the version was validated against this regex:  `[A-Za-z0-9_-.]+$`

Signed-off-by: David Kwon <dakwon@redhat.com>