### PR TITLE
Add Changelog for 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Quarkus Tools for Visual Studio Code Changelog
+
+## 1.1.0 (October 17, 2019)
+
+### Enhancements
+
+ * Improve documentation for default profiles. See [quarkus-ls#89](https://github.com/redhat-developer/quarkus-ls/issues/89)
+ * Validate application.properties: type value. See [quarkus-ls#33](https://github.com/redhat-developer/quarkus-ls/issues/33)
+ * Support for `textDocument/formatting`. See [quarkus-ls#24](https://github.com/redhat-developer/quarkus-ls/issues/24)
+ * Validate application.properties: required properties. See [quarkus-ls#21](https://github.com/redhat-developer/quarkus-ls/issues/21)
+ * Support for `textDocument/definition` for Java fields which have Config* annotation. See [quarkus-ls#4](https://github.com/redhat-developer/quarkus-ls/issues/4)
+  * Debug startup command to uses mvn if mvnw does not exist. See [#95](https://github.com/redhat-developer/vscode-quarkus/issues/95)
+ * Add snippet for Jaeger properties configuration. See [#93](https://github.com/redhat-developer/vscode-quarkus/issues/93)
+ * Add snippets for configuring Panache. See [#90](https://github.com/redhat-developer/vscode-quarkus/issues/90)
+ * Add welcome page with Quarkus information. See [#53](https://github.com/redhat-developer/vscode-quarkus/issues/53)
+
+### Bug Fixes
+
+ * Fix duplicate completion options for ConfigProperty. See [quarkus-ls#101](https://github.com/redhat-developer/quarkus-ls/issues/101)
+ * Fix issue where boolean completion for optional boolean value was not working. See [quarkus-ls#88](https://github.com/redhat-developer/quarkus-ls/issues/88)
+ * Fix issue where PropertiesModel start offset is -1. See [quarkus-ls#51](https://github.com/redhat-developer/quarkus-ls/issues/51)
+ * Ignore/include properties in application.properties depending on test scope. See [quarkus-ls#5](https://github.com/redhat-developer/quarkus-ls/issues/5)
+ * Corrected filename for mvnw.cmd (windows only). See [#105](https://github.com/redhat-developer/vscode-quarkus/pull/105)
+ * Validate initial input value, offer context on invalid values. See [#84](https://github.com/redhat-developer/vscode-quarkus/issues/84)
+
+### Others
+
+ * Update lsp4j version to 0.8.1. See [quarkus-ls#107](https://github.com/redhat-developer/quarkus-ls/pull/107)
+ * Freeze API for enumeration (String -> EnumItem). See [quarkus-ls#99](https://github.com/redhat-developer/quarkus-ls/issues/99)
+ * Use logo compatible with both light and dark modes. See [#96](https://github.com/redhat-developer/vscode-quarkus/issues/96)

--- a/README.md
+++ b/README.md
@@ -51,20 +51,22 @@ When editing `application.properties` files, you have access to:
 
 The following settings are supported:
   
-* `quarkus.tools.alwaysShowWelcomePage` : Determines whether to show the welcome page on extension startup.
 * `quarkus.tools.debug.terminateProcessOnExit` : Determines whether to terminate the quarkus:dev task after closing the debug session.
-* `quarkus.tools.formatting.surroundEqualsWithSpaces` : Insert spaces around the equals sign when formatting the application.properties file. Default is `false`.
 * `quarkus.tools.trace.server` : Trace the communication between VS Code and the Quarkus Language Server in the Output view.
 * `quarkus.tools.symbols.showAsTree` : Show Quarkus properties as tree (Outline). Default is `true`.
 * `quarkus.tools.validation.enabled` : Enables Quarkus validation. Default is `true`.
 * `quarkus.tools.validation.duplicate.severity` : Validation severity for duplicate Quarkus properties.
 Default is `warning`.
-* `quarkus.tools.validation.required.severity` : Validation severity for required Quarkus properties.
-Default is `none`.
 * `quarkus.tools.validation.syntax.severity` : Validation severity for Quarkus property syntax checking.
 Default is `error`.
 * `quarkus.tools.validation.unknown.severity` : Validation severity for unknown Quarkus properties. Default is `warning`.
 * `quarkus.tools.validation.unknown.excluded` : Array of properties to ignore for unknown Quarkus properties validation. Default is `[]`.
+
+Since 1.0.2:
+* `quarkus.tools.alwaysShowWelcomePage` : Determines whether to show the welcome page on extension startup.
+* `quarkus.tools.formatting.surroundEqualsWithSpaces` : Insert spaces around the equals sign when formatting the application.properties file. Default is `false`.
+* `quarkus.tools.validation.required.severity` : Validation severity for required Quarkus properties.
+Default is `none`.
         
 ## Contributing
 


### PR DESCRIPTION
CHANGELOG.md has been added.

The list of issues for the changelog were the issues from quarkus-ls and vscode-quarkus that had a milestone of "1.1.0"

The changelog looks like this:
![image](https://user-images.githubusercontent.com/20326645/66949626-d97f5380-f024-11e9-8b57-96dc581625c4.png)

Signed-off-by: David Kwon <dakwon@redhat.com>