### PR TITLE
Change "Quarkus: Generate a Maven Project" command ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "starter"
   ],
   "activationEvents": [
-    "onCommand:quarkusTools.createMavenProject",
+    "onCommand:quarkusTools.createProject",
     "onCommand:quarkusTools.addExtension",
     "onCommand:quarkusTools.debugQuarkusProject",
     "onCommand:quarkusTools.welcome",
@@ -60,7 +60,7 @@
     ],
     "commands": [
       {
-        "command": "quarkusTools.createMavenProject",
+        "command": "quarkusTools.createProject",
         "title": "Quarkus: Generate a Maven project"
       },
       {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,7 +98,7 @@ function registerVSCodeCommands(context: ExtensionContext) {
   /**
    * Command for creating a Quarkus Maven project
    */
-  context.subscriptions.push(commands.registerCommand('quarkusTools.createMavenProject', () => {
+  context.subscriptions.push(commands.registerCommand('quarkusTools.createProject', () => {
     generateProjectWizard();
   }));
 

--- a/webviews/templates/welcome.ejs
+++ b/webviews/templates/welcome.ejs
@@ -30,7 +30,7 @@
   <div class="section-div">
     <h2 class="section-title">Get started</h2>
     <p>Create a new Maven based Quarkus project or open an existing Quarkus project to get started.</p>
-    <a href="command:quarkusTools.createMavenProject"><button>Create Quarkus project</button></a>
+    <a href="command:quarkusTools.createProject"><button>Create Quarkus project</button></a>
   </div>
 
   <div class="row">


### PR DESCRIPTION
Changes the command id for creating Quarkus projects.
The term "Maven" was removed from the id because the command would also allow the users to create Gradle projects in the future.

Also, this change would be nice because adding the "Create a Quarkus Project" link for the Java extension pack overview page: https://github.com/Microsoft/vscode-java-pack, requires the vscode-quarkus command id for creating Quarkus projects.

Signed-off-by: David Kwon <dakwon@redhat.com>