### PR TITLE
Display welcome page on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "onCommand:quarkusTools.addExtension",
     "onCommand:quarkusTools.debugQuarkusProject",
     "onCommand:quarkusTools.welcome",
-    "onLanguage:quarkus-properties"
+    "onLanguage:quarkus-properties",
+    "*"
   ],
   "main": "./dist/extension",
   "extensionDependencies": [
@@ -113,7 +114,7 @@
         },
         "quarkus.tools.alwaysShowWelcomePage": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Determines whether to show the welcome page on extension startup."
         },
         "quarkus.tools.starter.api": {

--- a/src/QuarkusConfig.ts
+++ b/src/QuarkusConfig.ts
@@ -70,7 +70,7 @@ export namespace QuarkusConfig {
   }
 
   export function getAlwaysShowWelcomePage(): boolean {
-    return workspace.getConfiguration().get<boolean>(ALWAYS_SHOW_WELCOME_PAGE, true);
+    return workspace.getConfiguration().get<boolean>(ALWAYS_SHOW_WELCOME_PAGE, false);
   }
 
   export function getTerminateProcessOnDebugExit(): TerminateProcessConfig {


### PR DESCRIPTION
Fixes #127 

This PR implements a creative/hacky fix to display the welcome page on extension install. (ie, displays the welcome page when vscode-quarkus is installed)

The fix was to have vscode-quarkus activate on startup, show the welcome page and have vscode-quarkus manually edit the package.json file so that the startup activation event is removed.

Hi @jrieken, what do you think about this fix?

I have created a feature request for an "onExtensionInstalled" activation event to the VS Code GitHub page here: https://github.com/microsoft/vscode/issues/83451



