### PR TITLE
Have proper group ids for extensions when generating a project

### DIFF
--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -67,10 +67,7 @@ function removeDuplicateArtifactIds(extensions: QExtension[]): QExtension[] {
 
 export async function downloadProject(state: ProjectGenState): Promise<ZipFile> {
   const apiUrl: string = QuarkusConfig.getApiUrl();
-  const chosenExtArtifactIds: string[] = state.extensions!.map((it) => it.artifactId);
-  const chosenIds: string[] = chosenExtArtifactIds.map((artifactId) => {
-    return 'io.quarkus:' + artifactId;
-  });
+  const chosenIds: string[] = state.extensions!.map((it) => `${it.groupId}:${it.artifactId}`);
 
   const qProjectUrl: string = `${apiUrl}/download?` +
     `g=${state.groupId}&` +


### PR DESCRIPTION
This PR fixes the issue where generating a new project with a Camel extension, causes the pom.xml to contain an incorrect groupid.

Before this PR:
pom.xml
```
<dependency>
  <groupId>io.quarkus</groupId>
  <artifactId>camel-quarkus-core</artifactId>
</dependency>
```

After this PR:
pom.xml
```
<dependency>
  <groupId>org.apache.camel.quarkus</groupId>
  <artifactId>camel-quarkus-core</artifactId>
</dependency>
```

Signed-off-by: David Kwon <dakwon@redhat.com>