### PR TITLE
Correct step number when adding extensions

### DIFF
--- a/src/generateProject/pickExtensions.ts
+++ b/src/generateProject/pickExtensions.ts
@@ -42,25 +42,28 @@ let addLastUsed: boolean;
 export async function pickExtensionsWithoutLastUsed(
   input: MultiStepInput,
   state: Partial<State>,
+  step?: number,
   next?: (input: MultiStepInput, state: Partial<State>) => any) {
 
   addLastUsed = false;
-  await pickExtensions(input, state, next);
+  await pickExtensions(input, state, step, next);
 }
 
 export async function pickExtensionsWithLastUsed(
   input: MultiStepInput,
   state: Partial<State>,
+  step?: number,
   next?: (input: MultiStepInput, state: Partial<State>) => any) {
 
   addLastUsed = true;
-  await pickExtensions(input, state, next);
+  await pickExtensions(input, state, step, next);
 }
 
 async function pickExtensions(
   input: MultiStepInput,
   state: Partial<State>,
-  next: (input: MultiStepInput, state: Partial<State>) => any) {
+  step?: number,
+  next?: (input: MultiStepInput, state: Partial<State>) => any) {
 
   let allExtensions: QExtension[];
 
@@ -82,7 +85,7 @@ async function pickExtensions(
 
     pick = await input.showQuickPick({
       title: 'Quarkus Tools',
-      step: input.getStepNumber(),
+      step: step ? step : input.getStepNumber(),
       totalSteps: state.totalSteps,
       placeholder: 'Pick extensions',
       items: quickPickItems,


### PR DESCRIPTION
Fixes a bug introduced with https://github.com/redhat-developer/vscode-quarkus/pull/135

When adding extensions with the VS Code command, the step number was wrong. 

Before this PR:
![image](https://user-images.githubusercontent.com/20326645/68340427-6e212280-00b4-11ea-97d2-63a440299dec.png)


After this PR:
![image](https://user-images.githubusercontent.com/20326645/68340381-58abf880-00b4-11ea-9813-712731f8b211.png)


Signed-off-by: David Kwon <dakwon@redhat.com>