### PR TITLE
Use context global state to store defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,59 +123,6 @@
           "description": "Quarkus API base URL",
           "scope": "window"
         },
-        "quarkus.tools.starter.defaults": {
-          "type": "object",
-          "default": {},
-          "description": "Default values for the project generation wizard.",
-          "scope": "window",
-          "properties": {
-            "buildTool": {
-              "type": "string",
-              "enum": [
-                "Maven",
-                "Gradle"
-              ],
-              "scope": "window",
-              "description": "Default build tool"
-            },
-            "groupId": {
-              "type": "string",
-              "pattern": "^[A-Za-z0-9_\\-.]+$",
-              "scope": "window",
-              "description": "Default groupId"
-            },
-            "artifactId": {
-              "type": "string",
-              "pattern": "^[A-Za-z0-9_\\-.]+$",
-              "scope": "window",
-              "description": "Default artifactId"
-            },
-            "projectVersion": {
-              "type": "string",
-              "pattern": "^[A-Za-z0-9_\\-.]+$",
-              "scope": "window",
-              "description": "Default project version"
-            },
-            "packageName": {
-              "type": "string",
-              "pattern": "^[A-Za-z0-9_\\-.]+$",
-              "scope": "window",
-              "description": "Default package name"
-            },
-            "resourceName": {
-              "type": "string",
-              "pattern": "^[A-Za-z0-9_\\-.]+$",
-              "scope": "window",
-              "description": "Default resource name"
-            },
-            "extensions": {
-              "default": [],
-              "type": "array",
-              "scope": "window",
-              "description": "Store previously selected Quarkus extensions"
-            }
-          }
-        },
         "quarkus.tools.formatting.surroundEqualsWithSpaces": {
           "type": "boolean",
           "default": false,

--- a/src/QuarkusConfig.ts
+++ b/src/QuarkusConfig.ts
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 import {
-  BuildToolName,
   DEFAULT_API_URL,
-  DEFAULT_BUILD_TOOL,
-  DEFAULT_GROUP_ID,
-  DEFAULT_ARTIFACT_ID,
-  DEFAULT_PROJECT_VERSION,
-  DEFAULT_PACKAGE_NAME,
-  DEFAULT_RESOURCE_NAME
 } from './definitions/constants';
 import { workspace } from 'vscode';
 
@@ -34,46 +27,11 @@ export namespace QuarkusConfig {
   export const QUARKUS_CONFIG_NAME = 'quarkus.tools';
 
   export const STARTER_API = 'quarkus.tools.starter.api';
-  export const BUILD_TOOL = 'quarkus.tools.starter.defaults.buildTool';
-  export const GROUP_ID = 'quarkus.tools.starter.defaults.groupId';
-  export const ARTIFACT_ID = 'quarkus.tools.starter.defaults.artifactId';
-  export const PROJECT_VERSION = 'quarkus.tools.starter.defaults.projectVersion';
-  export const PACKAGE_NAME = 'quarkus.tools.starter.defaults.packageName';
-  export const RESOURCE_NAME = 'quarkus.tools.starter.defaults.resourceName';
-  export const EXTENSIONS = 'quarkus.tools.starter.defaults.extensions';
   export const ALWAYS_SHOW_WELCOME_PAGE = 'quarkus.tools.alwaysShowWelcomePage';
   export const DEBUG_TERMINATE_ON_EXIT = 'quarkus.tools.debug.terminateProcessOnExit';
 
   export function getApiUrl(): string {
     return workspace.getConfiguration().get<string>(STARTER_API, DEFAULT_API_URL);
-  }
-
-  export function getDefaultBuildTool(): BuildToolName {
-    return workspace.getConfiguration().get<BuildToolName>(BUILD_TOOL, DEFAULT_BUILD_TOOL);
-  }
-
-  export function getDefaultGroupId(): string {
-    return workspace.getConfiguration().get<string>(GROUP_ID, DEFAULT_GROUP_ID);
-  }
-
-  export function getDefaultArtifactId(): string {
-    return workspace.getConfiguration().get<string>(ARTIFACT_ID, DEFAULT_ARTIFACT_ID);
-  }
-
-  export function getDefaultProjectVersion(): string {
-    return workspace.getConfiguration().get<string>(PROJECT_VERSION, DEFAULT_PROJECT_VERSION);
-  }
-
-  export function getDefaultPackageName(): string {
-    return workspace.getConfiguration().get<string>(PACKAGE_NAME, DEFAULT_PACKAGE_NAME);
-  }
-
-  export function getDefaultResourceName(): string {
-    return workspace.getConfiguration().get<string>(RESOURCE_NAME, DEFAULT_RESOURCE_NAME);
-  }
-
-  export function getDefaultExtensions(): any[] {
-    return workspace.getConfiguration().get<string[]>(EXTENSIONS, []);
   }
 
   export function getAlwaysShowWelcomePage(): boolean {
@@ -82,10 +40,6 @@ export namespace QuarkusConfig {
 
   export function getTerminateProcessOnDebugExit(): TerminateProcessConfig {
     return workspace.getConfiguration().get<TerminateProcessConfig>(DEBUG_TERMINATE_ON_EXIT);
-  }
-
-  export function setDefaults(defaults: Defaults): void {
-    workspace.getConfiguration(QUARKUS_CONFIG_NAME).update('starter.defaults', defaults, true);
   }
 
   export function setAlwaysShowWelcomePage(value: boolean): void {
@@ -99,16 +53,6 @@ export namespace QuarkusConfig {
   function removeQuarkusConfigName(configName: string) {
     return configName.replace(QUARKUS_CONFIG_NAME + '.', '');
   }
-}
-
-interface Defaults {
-  buildTool: string;
-  groupId: string;
-  artifactId: string;
-  projectVersion: string;
-  packageName: string;
-  resourceName: string;
-  extensions: string[];
 }
 
 export enum TerminateProcessConfig {

--- a/src/QuarkusContext.ts
+++ b/src/QuarkusContext.ts
@@ -1,0 +1,88 @@
+import { ExtensionContext } from 'vscode';
+import {
+  BuildToolName,
+  DEFAULT_BUILD_TOOL,
+  DEFAULT_GROUP_ID,
+  DEFAULT_ARTIFACT_ID,
+  DEFAULT_PROJECT_VERSION,
+  DEFAULT_PACKAGE_NAME,
+  DEFAULT_RESOURCE_NAME
+} from './definitions/constants';
+
+export namespace QuarkusContext {
+  const BUILD_TOOL = 'quarkus.tools.starter.defaults.buildTool';
+  const GROUP_ID = 'quarkus.tools.starter.defaults.groupId';
+  const ARTIFACT_ID = 'quarkus.tools.starter.defaults.artifactId';
+  const PROJECT_VERSION = 'quarkus.tools.starter.defaults.projectVersion';
+  const PACKAGE_NAME = 'quarkus.tools.starter.defaults.packageName';
+  const RESOURCE_NAME = 'quarkus.tools.starter.defaults.resourceName';
+  const EXTENSIONS = 'quarkus.tools.starter.defaults.extensions';
+
+  let context: ExtensionContext | undefined = undefined;
+
+  export function setContext(extensionContext: ExtensionContext) {
+    context = extensionContext;
+  }
+
+  export function getDefaultBuildTool(): BuildToolName {
+    checkContext();
+    return context.globalState.get<BuildToolName>(BUILD_TOOL, DEFAULT_BUILD_TOOL);
+  }
+
+  export function getDefaultGroupId(): string {
+    checkContext();
+    return context.globalState.get<string>(GROUP_ID, DEFAULT_GROUP_ID);
+  }
+
+  export function getDefaultArtifactId(): string {
+    checkContext();
+    return context.globalState.get<string>(ARTIFACT_ID, DEFAULT_ARTIFACT_ID);
+  }
+
+  export function getDefaultProjectVersion(): string {
+    checkContext();
+    return context.globalState.get<string>(PROJECT_VERSION, DEFAULT_PROJECT_VERSION);
+  }
+
+  export function getDefaultPackageName(): string {
+    checkContext();
+    return context.globalState.get<string>(PACKAGE_NAME, DEFAULT_PACKAGE_NAME);
+  }
+
+  export function getDefaultResourceName(): string {
+    checkContext();
+    return context.globalState.get<string>(RESOURCE_NAME, DEFAULT_RESOURCE_NAME);
+  }
+
+  export function getDefaultExtensions(): any[] {
+    checkContext();
+    return context.globalState.get<string[]>(EXTENSIONS, []);
+  }
+
+  export function setDefaults(defaults: Defaults): void {
+    checkContext();
+    context.globalState.update(BUILD_TOOL, defaults.buildTool);
+    context.globalState.update(GROUP_ID, defaults.groupId);
+    context.globalState.update(ARTIFACT_ID, defaults.artifactId);
+    context.globalState.update(PROJECT_VERSION, defaults.projectVersion);
+    context.globalState.update(PACKAGE_NAME, defaults.packageName);
+    context.globalState.update(RESOURCE_NAME, defaults.resourceName);
+    context.globalState.update(EXTENSIONS, defaults.extensions);
+  }
+
+  function checkContext(): void {
+    if (!context) {
+      throw "Error: ExtensionContext is not set";
+    }
+  }
+}
+
+interface Defaults {
+  buildTool: string;
+  groupId: string;
+  artifactId: string;
+  projectVersion: string;
+  packageName: string;
+  resourceName: string;
+  extensions: string[];
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import { JdtLSCommands, QuarkusLS, VSCodeCommands } from './definitions/constant
 
 import { DidChangeConfigurationNotification, Disposable, LanguageClientOptions, LanguageClient, RequestType } from 'vscode-languageclient';
 import { ExtensionContext, commands, window, workspace } from 'vscode';
+import { QuarkusContext } from './QuarkusContext';
 import { addExtensionsWizard } from './addExtensions/addExtensionsWizard';
 import { createTerminateDebugListener } from './debugging/terminateProcess';
 import { generateProjectWizard } from './generateProject/generationWizard';
@@ -48,7 +49,7 @@ interface QuarkusPropertyDefinitionParams {
 }
 
 export function activate(context: ExtensionContext) {
-
+  QuarkusContext.setContext(context);
   displayWelcomePageIfNeeded(context);
 
   terminateDebugListener = createTerminateDebugListener(disposables);

--- a/src/generateProject/generationWizard.ts
+++ b/src/generateProject/generationWizard.ts
@@ -8,9 +8,9 @@ import * as fs from 'fs';
 import * as fse from 'fs-extra';
 
 import { INPUT_TITLE, BuildToolName } from '../definitions/constants';
-import { QuarkusConfig } from '../QuarkusConfig';
 import { MultiStepInput } from '../utils/multiStepUtils';
-import { OpenDialogOptions, QuickPickItem, Uri, commands, window } from 'vscode';
+import { ExtensionContext, OpenDialogOptions, QuickPickItem, Uri, commands, window } from 'vscode';
+import { QuarkusContext } from '../QuarkusContext';
 import { ProjectGenState } from '../definitions/inputState';
 import { QExtension } from '../definitions/QExtension';
 import { ZipFile } from 'yauzl';
@@ -39,7 +39,7 @@ export async function generateProjectWizard() {
       preferred: boolean;
     }
 
-    const defaultBuildTool: BuildToolName = QuarkusConfig.getDefaultBuildTool();
+    const defaultBuildTool: BuildToolName = QuarkusContext.getDefaultBuildTool();
     const quickPickItems: BuildToolPickItem[] = [
       {label: BuildToolName.Maven, preferred: BuildToolName.Maven === defaultBuildTool},
       {label: BuildToolName.Gradle, preferred: BuildToolName.Gradle === defaultBuildTool}
@@ -64,7 +64,7 @@ export async function generateProjectWizard() {
 
   async function inputGroupId(input: MultiStepInput, state: Partial<ProjectGenState>) {
 
-    const defaultInputBoxValue: string = QuarkusConfig.getDefaultGroupId();
+    const defaultInputBoxValue: string = QuarkusContext.getDefaultGroupId();
     const inputBoxValue: string = state.groupId ? state.groupId : defaultInputBoxValue;
 
     state.groupId = await input.showInputBox({
@@ -81,7 +81,7 @@ export async function generateProjectWizard() {
 
   async function inputArtifactId(input: MultiStepInput, state: Partial<ProjectGenState>) {
 
-    const defaultInputBoxValue: string = QuarkusConfig.getDefaultArtifactId();
+    const defaultInputBoxValue: string = QuarkusContext.getDefaultArtifactId();
     const inputBoxValue: string = state.artifactId ? state.artifactId : defaultInputBoxValue;
 
     state.artifactId = await input.showInputBox({
@@ -97,7 +97,7 @@ export async function generateProjectWizard() {
 
   async function inputProjectVersion(input: MultiStepInput, state: Partial<ProjectGenState>) {
 
-    const defaultInputBoxValue: string = QuarkusConfig.getDefaultProjectVersion();
+    const defaultInputBoxValue: string = QuarkusContext.getDefaultProjectVersion();
     const inputBoxValue: string = state.projectVersion ? state.projectVersion : defaultInputBoxValue;
 
     state.projectVersion = await input.showInputBox({
@@ -113,7 +113,7 @@ export async function generateProjectWizard() {
 
   async function inputPackageName(input: MultiStepInput, state: Partial<ProjectGenState>) {
 
-    const defaultInputBoxValue: string = QuarkusConfig.getDefaultPackageName();
+    const defaultInputBoxValue: string = QuarkusContext.getDefaultPackageName();
     const inputBoxValue: string = state.packageName ? state.packageName : (state.groupId ? state.groupId : defaultInputBoxValue);
 
     state.packageName = await input.showInputBox({
@@ -129,7 +129,7 @@ export async function generateProjectWizard() {
 
   async function inputResourceName(input: MultiStepInput, state: Partial<ProjectGenState>) {
 
-    const defaultInputBoxValue: string = QuarkusConfig.getDefaultResourceName();
+    const defaultInputBoxValue: string = QuarkusContext.getDefaultResourceName();
     const inputBoxValue: string = state.resourceName ? state.resourceName : defaultInputBoxValue;
 
     state.resourceName = await input.showInputBox({
@@ -154,7 +154,7 @@ export async function generateProjectWizard() {
     state.targetDir = await getTargetDirectory(state.artifactId);
 
     const projectGenState: ProjectGenState = state as ProjectGenState;
-    saveDefaultsToConfig(projectGenState);
+    saveDefaults(projectGenState);
     deleteFolderIfExists(getNewProjectDirectory(projectGenState));
     await downloadAndSetupProject(projectGenState);
   } catch (message) {
@@ -204,8 +204,8 @@ async function showOpenFolderDialog(customOptions: OpenDialogOptions): Promise<U
   }
 }
 
-function saveDefaultsToConfig(state: ProjectGenState): void {
-  QuarkusConfig.setDefaults({
+function saveDefaults(state: ProjectGenState): void {
+  QuarkusContext.setDefaults({
     buildTool: state.buildTool,
     groupId: state.groupId,
     artifactId: state.artifactId,

--- a/src/generateProject/pickExtensions.ts
+++ b/src/generateProject/pickExtensions.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { QUARKUS_GROUP_ID } from '../definitions/constants';
-import { QuarkusConfig } from '../QuarkusConfig';
+import { QuarkusContext } from '../QuarkusContext';
 import { MultiStepInput } from '../utils/multiStepUtils';
 import { QExtension } from '../definitions/QExtension';
 import { State } from '../definitions/inputState';
@@ -133,7 +133,7 @@ async function pickExtensions(
 
 function getDefaultQExtensions(allExtensions: QExtension[]): QExtension[] {
   const result: QExtension[] = [];
-  let defaultExtensionIds: any[] = QuarkusConfig.getDefaultExtensions();
+  let defaultExtensionIds: any[] = QuarkusContext.getDefaultExtensions();
 
   defaultExtensionIds = defaultExtensionIds.filter((extensionId: any) => {
     return typeof extensionId === 'string' && extensionId.length > 0;


### PR DESCRIPTION
This PR stores the default build tool, groupId, artifactId, project version, package name and resource name in the extension's `context.globalState`.

Signed-off-by: David Kwon <dakwon@redhat.com>