### PR TITLE
Remove option to add zero extensions

### DIFF
--- a/src/generateProject/pickExtensions.ts
+++ b/src/generateProject/pickExtensions.ts
@@ -157,26 +157,27 @@ function getDefaultQExtensions(allExtensions: QExtension[]): QExtension[] {
 }
 
 function getItems(selected: QExtension[], unselected: QExtension[], defaults: QExtension[]): QuickPickItem[] {
-  const items: QuickPickItem[] = selected.concat(unselected).map((it) => {
+  let items: QuickPickItem[] = [];
+
+  if (selected.length === 0 && defaults.length > 0 && addLastUsed) {
+    addLastUsedOption(items, defaults);
+  } else if (selected.length > 0) {
+    items.push({
+      type: Type.Stop,
+      label: `$(tasklist) ${selected.length} extensions selected`,
+      description: '',
+      detail: 'Press <Enter>  to continue'
+    });
+  }
+
+  items = items.concat(selected.concat(unselected).map((it) => {
     return {
       type: Type.Extension,
       label: `${selected.some((other) => it.artifactId === other.artifactId) ? '$(check) ' : ''}${it.name}`,
       description: `(${it.artifactId})`,
       artifactId: it.artifactId
     };
-  });
-
-  // Push the dependencies selection stopper on top of the dependencies list
-  items.unshift({
-    type: Type.Stop,
-    label: `$(tasklist) ${selected.length} extensions selected`,
-    description: '',
-    detail: 'Press <Enter>  to continue'
-  });
-
-  if (selected.length === 0 && defaults.length > 0 && addLastUsed) {
-    addLastUsedOption(items, defaults);
-  }
+  }));
 
   return items;
 }
@@ -185,7 +186,7 @@ function addLastUsedOption(items: QuickPickItem[], prevExtensions: QExtension[])
 
   const extensionNames = prevExtensions.map((it) => it.name).join(', ');
 
-  items.unshift({
+  items.push({
     type: Type.LastUsed,
     label: `$(clock) Last used`,
     description: '',


### PR DESCRIPTION
Fixes #76

The option to add extensions is gone when zero extensions are selected.

No extensions selected:
![image](https://user-images.githubusercontent.com/20326645/68432470-79db1a80-0182-11ea-9782-b6782a763362.png)

At least one extension selected:
![image](https://user-images.githubusercontent.com/20326645/68432498-8b242700-0182-11ea-91e9-74dc26dd9cba.png)

This works when choosing extensions using the `Quarkus: Generate a Quarkus project command` and the `Quarkus: Add extensions to current project` command.


Signed-off-by: David Kwon <dakwon@redhat.com>