### PR TITLE
Document support for Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,14 @@ and a [Quarkus jdt.ls extension](https://github.com/redhat-developer/quarkus-ls/
 
 ![](images/propertiesSupport.png)
 
-## Quarkus project wizards
-  * Generate a Quarkus project, based on https://code.quarkus.io/
-    - Call `Quarkus: Generate a Quarkus project` from the VS Code command palette
-  * Add Quarkus extensions to current Quarkus project
-    - Call `Quarkus: Add extensions to current project` from the VS Code command palette
+## Quarkus VS Code Commands
+The following commands are supported for both Maven and Gradle Quarkus projects:
+
+  * `Quarkus: Generate a Quarkus project`: Generate a Quarkus project, based on https://code.quarkus.io/
+  * `Quarkus: Add extensions to current project`: Add Quarkus extensions to currently opened Quarkus project
+  * `Quarkus: Debug current Quarkus project`: Launches the Maven `quarkus:dev` plugin or the Gradle `quarkusDev` command and automatically attaches a debugger
+
+  
 
 ## Quarkus `application.properties` Features
   * Completion support for Quarkus properties
@@ -22,10 +25,6 @@ and a [Quarkus jdt.ls extension](https://github.com/redhat-developer/quarkus-ls/
   * Validation support for Quarkus properties 
   * Support for Quarkus profiles
   * Outline support (flat or tree view)
-
-## Quarkus debug command
-  Launches the Maven `quarkus:dev` plugin or the Gradle `quarkusDev` command and automatically attaches a debugger
-  * Call `Quarkus: Debug current Quarkus project` from the VS Code command palette
 
 ## Quarkus code snippets
 This extension provides several code snippets, available when editing Java files:

--- a/webviews/templates/welcome.ejs
+++ b/webviews/templates/welcome.ejs
@@ -13,6 +13,7 @@
   <div class="section-div">
     <h2 class="title-header">Quarkus Tools for <%= appName %></h2>
     <p class="no-bottom-margin">Welcome! This extension provides tools to get you up and running with Quarkus application development in <%= appName %>.</p>
+    <p class="no-bottom-margin">Both Maven and Gradle Quarkus projects are supported.</p>
   </div>
 
   <div class="section-div">


### PR DESCRIPTION
Fixes #107 

This PR changes the readme from this:
![image](https://user-images.githubusercontent.com/20326645/68432726-01c12480-0183-11ea-8277-4912c615e363.png)
![image](https://user-images.githubusercontent.com/20326645/68432748-0be32300-0183-11ea-8f0d-e0f846c7096c.png)


to this:
![image](https://user-images.githubusercontent.com/20326645/68432705-f968e980-0182-11ea-80f0-26da48942663.png)

Any thoughts about this new format?

I've also added a new sentence to the welcome page about Maven and Gradle support.

When I created #107 I was under the impression that Gradle support was not going to be fully implemented for project generation, debugging and add extensions, so I was going to document what works and what doesn't. Currently in master, all three work, so this issue seems quick. 

Unless there anything else that should be documented in terms of Gradle support? 

Signed-off-by: David Kwon <dakwon@redhat.com>