### PR TITLE
Use language instead of pattern for documentSelector

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -128,7 +128,7 @@ function connectToLS() {
   return requirements.resolveRequirements().then(requirements => {
     const clientOptions: LanguageClientOptions = {
       documentSelector: [
-        { scheme: 'file', pattern: '**/application.properties' }
+        { scheme: 'file', language: 'quarkus-properties' }
       ],
       // wrap with key 'settings' so it can be handled same a DidChangeConfiguration
       initializationOptions: {


### PR DESCRIPTION
Use language instead of pattern for documentSelector

As 'quarkus-properties' is defined as language in package.json, I think it's better to use it for documentSelector.

Signed-off-by: azerr <azerr@redhat.com>