### PR TITLE
Add disposables to context.subscriptions

### DIFF
--- a/src/debugging/terminateProcess.ts
+++ b/src/debugging/terminateProcess.ts
@@ -20,7 +20,7 @@ import { getRunningQuarkusDevTasks } from '../utils/tasksUtils';
 import { BuildSupport } from '../buildSupport/BuildSupport';
 import { getBuildSupport } from '../buildSupport/BuildSupportUtils';
 
-export function createTerminateDebugListener(disposables: Disposable[]): Disposable {
+export function createTerminateDebugListener(): Disposable {
 
   return debug.onDidTerminateDebugSession(async (debugSession: DebugSession) => {
 
@@ -41,7 +41,7 @@ export function createTerminateDebugListener(disposables: Disposable[]): Disposa
       quarkusDevTaskExe.terminate();
     }
 
-  }, null, disposables);
+  });
 }
 
 function checkHasPreLaunchTask(debugSession: DebugSession): void {


### PR DESCRIPTION
This PR adds disposables to `context.subscriptions` instead of a separate array that is manually disposed of in the `deactivate()` function.

The contents of `context.subscriptions` are automatically disposed of when the extension is deactivated. [Source](https://github.com/microsoft/vscode/blob/12b7d0aafeaaa65e683e9289126bc75db2278c5c/src/vs/vscode.d.ts#L4941-L4945)

Signed-off-by: David Kwon <dakwon@redhat.com>