### PR TITLE
Activate when **/src/main/resources/application.properties is present

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "onCommand:quarkusTools.addExtension",
     "onCommand:quarkusTools.debugQuarkusProject",
     "onCommand:quarkusTools.welcome",
+    "workspaceContains:**/src/main/resources/application.properties",
     "onLanguage:quarkus-properties"
   ],
   "main": "./dist/extension",


### PR DESCRIPTION
this helps launching the welcome page on startup, when opening a quarkus
project. See #127

The big caveat though, is it'll wrongly identify any spring boot project (having
a src/main/resources/application.properties) as a quarkus project.