### PR TITLE
Allow add zero extension when generating project

### DIFF
--- a/src/addExtensions/addExtensionsWizard.ts
+++ b/src/addExtensions/addExtensionsWizard.ts
@@ -21,7 +21,7 @@ import { QExtension } from "../definitions/QExtension";
 import { QuickPickItem, Terminal, Uri, WorkspaceFolder, window, workspace } from "vscode";
 import { ITerminalOptions, terminalCommandRunner } from "../terminal/terminalCommandRunner";
 import { getBuildSupport, searchBuildFile } from '../buildSupport/BuildSupportUtils';
-import { pickExtensionsWithoutLastUsed } from "../generateProject/pickExtensions";
+import { pickExtensions } from "../generateProject/pickExtensions";
 import { TerminalCommand } from "../buildSupport/BuildSupport";
 
 export async function addExtensionsWizard() {
@@ -63,7 +63,7 @@ export async function addExtensionsWizard() {
 
     state.workspaceFolder = workspace.getWorkspaceFolder(state.buildFilePath);
     state.buildSupport = await getBuildSupport(state.workspaceFolder);
-    return state.wizardInterrupted ? null : (input: MultiStepInput) => pickExtensionsWithoutLastUsed(input, state, currentStep);
+    return state.wizardInterrupted ? null : (input: MultiStepInput) => pickExtensions(input, state, { showLastUsed: false, allowZeroExtensions: false, step: currentStep });
   }
 
   await collectInputs(state);

--- a/src/generateProject/generationWizard.ts
+++ b/src/generateProject/generationWizard.ts
@@ -15,7 +15,7 @@ import { ProjectGenState } from '../definitions/inputState';
 import { QExtension } from '../definitions/QExtension';
 import { ZipFile } from 'yauzl';
 import { downloadProject } from '../utils/requestUtils';
-import { pickExtensionsWithLastUsed } from './pickExtensions';
+import { pickExtensions } from './pickExtensions';
 import { validateArtifactId, validateGroupId, validatePackageName, validateResourceName, validateVersion } from './validateInput';
 
 /**
@@ -140,7 +140,7 @@ export async function generateProjectWizard() {
       prompt: 'Your resource name',
       validate: validateResourceName
     });
-    return state.wizardInterrupted ? null : (input: MultiStepInput) => pickExtensionsWithLastUsed(input, state);
+    return state.wizardInterrupted ? null : (input: MultiStepInput) => pickExtensions(input, state, { showLastUsed: true, allowZeroExtensions: true });
   }
 
   await collectInputs(state);


### PR DESCRIPTION
Fixes the problem where the user couldn't select zero extensions when generating a new project using the wizard.

Signed-off-by: David Kwon <dakwon@redhat.com>