### PR TITLE
Provide full GAV when adding Quarkus extensions

### DIFF
--- a/src/addExtensions/addExtensionsWizard.ts
+++ b/src/addExtensions/addExtensionsWizard.ts
@@ -77,10 +77,10 @@ export async function addExtensionsWizard() {
 }
 
 async function executeAddExtensionsCommand(state: AddExtensionsState): Promise<Terminal> {
-  const artifactIds: string[] = getArtifactIds(state.extensions);
+  const extensionGAVs: string[] = getExtensionGAVs(state.extensions);
   let terminalOptions: ITerminalOptions = {} as ITerminalOptions;
 
-  const terminalCommand: TerminalCommand = await state.buildSupport.getQuarkusAddExtensionsCommand(state.workspaceFolder, artifactIds, { buildFilePath: state.buildFilePath.fsPath });
+  const terminalCommand: TerminalCommand = await state.buildSupport.getQuarkusAddExtensionsCommand(state.workspaceFolder, extensionGAVs, { buildFilePath: state.buildFilePath.fsPath });
   if (terminalCommand.cwd) {
     terminalOptions.cwd = path.dirname(terminalCommand.cwd);
   }
@@ -94,6 +94,8 @@ async function executeAddExtensionsCommand(state: AddExtensionsState): Promise<T
   return await terminalCommandRunner.runInTerminal(terminalCommand.command, terminalOptions);
 }
 
-function getArtifactIds(extensions: QExtension[]): string[] {
-  return extensions.map((it) => it.artifactId);
+function getExtensionGAVs(extensions: QExtension[]): string[] {
+  return extensions.map((it) => {
+    return it.getGroupIdArtifactIdString();
+  });
 }

--- a/src/buildSupport/BuildSupport.ts
+++ b/src/buildSupport/BuildSupport.ts
@@ -62,12 +62,12 @@ export abstract class BuildSupport {
   }
 
   /**
-   * Returns a command that adds all extensions in `artifactIds`
+   * Returns a command that adds all extensions listed in `extensionGAVs`
    * @param workspaceFolder
-   * @param artifactIds
+   * @param extensionGAVs
    * @param options
    */
-  public abstract getQuarkusAddExtensionsCommand(workspaceFolder: WorkspaceFolder, artifactIds: string[], options?: TerminalCommandOptions): Promise<TerminalCommand>;
+  public abstract getQuarkusAddExtensionsCommand(workspaceFolder: WorkspaceFolder, extensionGAVs: string[], options?: TerminalCommandOptions): Promise<TerminalCommand>;
 
   /**
    * Returns a command that runs the Quarkus application using 'Quarkus Dev'

--- a/src/buildSupport/GradleBuildSupport.ts
+++ b/src/buildSupport/GradleBuildSupport.ts
@@ -16,8 +16,8 @@ export class GradleBuildSupport extends BuildSupport {
     });
   }
 
-  public async getQuarkusAddExtensionsCommand(workspaceFolder: WorkspaceFolder, artifactIds: string[], options?: TerminalCommandOptions): Promise<TerminalCommand> {
-    const addExtensions: string = `addExtension --extensions="${artifactIds.join(',')}"`;
+  public async getQuarkusAddExtensionsCommand(workspaceFolder: WorkspaceFolder, extensionGAVs: string[], options?: TerminalCommandOptions): Promise<TerminalCommand> {
+    const addExtensions: string = `addExtension --extensions="${extensionGAVs.join(',')}"`;
     const buildGradlePath: string = `-b "${await formattedPathForTerminal(options.buildFilePath)}"`;
     const gradle: string = await this.getCommand(workspaceFolder, options && options.buildFilePath, { windows: options && options.windows });
     const command = [gradle, addExtensions, buildGradlePath].join(' ');

--- a/src/buildSupport/MavenBuildSupport.ts
+++ b/src/buildSupport/MavenBuildSupport.ts
@@ -15,8 +15,8 @@ export class MavenBuildSupport extends BuildSupport {
     });
   }
 
-  public async getQuarkusAddExtensionsCommand(workspaceFolder: WorkspaceFolder, artifactIds: string[], options?: TerminalCommandOptions): Promise<TerminalCommand> {
-    const addExtensions: string = `quarkus:add-extension -Dextensions="${artifactIds.join(',')}"`;
+  public async getQuarkusAddExtensionsCommand(workspaceFolder: WorkspaceFolder, extensionGAVs: string[], options?: TerminalCommandOptions): Promise<TerminalCommand> {
+    const addExtensions: string = `quarkus:add-extension -Dextensions="${extensionGAVs.join(',')}"`;
     const pomPath: string = options.buildFilePath ? `-f "${await formattedPathForTerminal(options.buildFilePath)}"` : '';
     const mvn: string = await this.getCommand(workspaceFolder, options && options.buildFilePath, { windows: options && options.windows });
     const command: string = [mvn, addExtensions, pomPath].join(' ');


### PR DESCRIPTION
Fixes problem where camel extensions weren't being added for gradle projects when adding extensions with the Add Extensions wizard. 

When constructing the Maven/Gradle command to add a quarkus extension, this PR provides a GAV (without version) name of the quarkus extension to add. Previosly, only the extension's artifact ID was being provided.

For both Maven and Gradle projects, GAV (without version) will work according to these links:
https://quarkus.io/guides/maven-tooling#dealing-with-extensions
https://quarkus.io/guides/gradle-tooling#dealing-with-extensions

Signed-off-by: David Kwon <dakwon@redhat.com>