### PR TITLE
Ignore images/

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -5,5 +5,6 @@
 node_modules/
 src/
 out/
+images/
 tsconfig.json
 webpack.config.js


### PR DESCRIPTION
Ignores the `images/` directory when packaging the extension with `vsce package`.
https://code.visualstudio.com/api/working-with-extensions/publishing-extension#.vscodeignore

The resulting vsix file is about 0.5mb smaller.

Signed-off-by: David Kwon <dakwon@redhat.com>