### PR TITLE
Use API to check if tasks.json and launch.json exist

### DIFF
--- a/src/debugging/LaunchConfigCreator.ts
+++ b/src/debugging/LaunchConfigCreator.ts
@@ -49,14 +49,26 @@ export class LaunchConfigCreator {
   }
 
   private async createLaunchJsonIfMissing(): Promise<void> {
+    const configurationsKey = 'configurations';
+    const launchKey = 'launch';
+    const versionKey = 'version';
+    const launchVersion = '0.2.0';
 
-    if (fs.existsSync(this.launchJsonFile)) {
+    const workspaceConfiguration = workspace.getConfiguration(launchKey, this.workspaceFolder.uri);
+
+    // Get all registered launch configurations and version
+    const configurations =  workspaceConfiguration.get(configurationsKey);
+    const version = workspaceConfiguration.get(versionKey);
+
+    if (Array.isArray(configurations) && version) {
       return;
     }
 
-    await workspace.getConfiguration('launch', this.workspaceFolder.uri).update('version', "0.2.0");
-    await workspace.getConfiguration('launch', this.workspaceFolder.uri).update('configurations', []);
+    // Create launch.json file with empty list of configurations and with version 0.2.0
+    await workspaceConfiguration.update(versionKey, launchVersion);
+    await workspaceConfiguration.update(configurationsKey, []);
 
+    // If launch.json was created in .vscode/ directory, add special comments on top of the file
     if (fs.existsSync(this.launchJsonFile)) {
       this.prependLaunchJsonComment();
     }

--- a/src/debugging/TaskCreator.ts
+++ b/src/debugging/TaskCreator.ts
@@ -50,20 +50,29 @@ export class TaskCreator {
   }
 
   /**
-   * Creates a tasks.json file (with no tasks) in .vscode/ directory, if
+   * Creates a tasks.json file (with no tasks), if
    * one does not exist already
-   * @param dotVSCodeDir absolute path to the .vscode/ directory
    */
   private async createTasksJsonIfMissing(): Promise<void> {
+    const tasksKey = 'tasks';
+    const versionKey = 'version';
+    const version = '2.0.0';
 
-    if (fs.existsSync(this.tasksJsonFile)) {
+    const workspaceConfiguration = workspace.getConfiguration(tasksKey, this.workspaceFolder.uri);
+
+    // Get all registered tasks and current version
+    const tasks = workspaceConfiguration.get(tasksKey);
+    const currentVersion = workspaceConfiguration.get(versionKey);
+
+    if (Array.isArray(tasks) && currentVersion) {
       return;
     }
 
-    // create tasks.json file in .vscode/
-    await workspace.getConfiguration('tasks', this.workspaceFolder.uri).update('version', "2.0.0");
-    await workspace.getConfiguration('tasks', this.workspaceFolder.uri).update('tasks', []);
+    // Create tasks.json file with empty list of tasks and with version 2.0.0
+    await workspaceConfiguration.update(versionKey, version);
+    await workspaceConfiguration.update(tasksKey, []);
 
+    // If tasks.json was created in .vscode/ directory, add special comments on top of the file
     if (fs.existsSync(this.tasksJsonFile)) {
       this.prependTasksJsonComment();
     }


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>
This PR suggests changes to use VS Code API to check if the workspace already has places (launch.json and tasks.json) to add new debug configuration and new task.

It could be useful if these configuration files are not located in .vscode folder. In case of Theia, they are in .theia folder

Which problem I've tried to solve: https://github.com/eclipse/che/issues/15523

@xorye @angelozerr @fbricon  Could you please take a look