### PR TITLE
Fix onLanguage qute-html

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "workspaceContains:**/src/main/resources/application.properties",
     "onLanguage:quarkus-properties",
     "onLanguage:java",
-    "onLanguage:qute"
+    "onLanguage:qute-html"
   ],
   "main": "./dist/extension",
   "extensionDependencies": [


### PR DESCRIPTION
This PR fixes the onLanguage activation rule so that it has the correct language ID for Qute HTML

Signed-off-by: David Kwon <dakwon@redhat.com>