### PR TITLE
Allow section tags within HTML tags

### DIFF
--- a/language-support/qute/qute-html.tmLanguage.json
+++ b/language-support/qute/qute-html.tmLanguage.json
@@ -4,7 +4,7 @@
     "L:meta.tag": {
       "patterns": [
         {
-          "include": "grammar.qute#expression"
+          "include": "grammar.qute#templates"
         },
         {
           "include": "grammar.qute#comment"

--- a/language-support/qute/qute.tmLanguage.json
+++ b/language-support/qute/qute.tmLanguage.json
@@ -8,16 +8,23 @@
       "include": "#parameter_declaration"
     },
     {
-      "include": "#section_start_tag"
-    },
-    {
-      "include": "#section_end_tag"
-    },
-    {
-      "include": "#expression"
+      "include": "#templates"
     }
   ],
   "repository": {
+    "templates": {
+      "patterns": [
+        {
+          "include": "#section_start_tag"
+        },
+        {
+          "include": "#section_end_tag"
+        },
+        {
+          "include": "#expression"
+        }
+      ]
+    },
     "parameter_declaration": {
       "begin": "(?<!\\\\){@",
       "end": "(?<!\\\\)}",
@@ -341,7 +348,7 @@
           "name": "variable.language.this.java"
         },
         {
-          "match": "\\b(in|as|eq|ne|gt|ge|lt|le)\\b",
+          "match": "\\b(in|is|as|eq|ne|gt|ge|lt|le)\\b",
           "name": "keyword.operator"
         }
       ]

--- a/language-support/qute/test.qute.html
+++ b/language-support/qute/test.qute.html
@@ -20,8 +20,8 @@
       {/if}
       </p>
     {/for}
-
     First name: <input type="text" name="fname" value="{person.name}">
+    First name: <input type="text" name="fname" value="{#if item.name is 'sword'}slice and dice{#else}not a sword{/if}">
 </body>
 </html>
 


### PR DESCRIPTION
This PR adds syntax highlighting for Qute section tags (if, else, for etc.) within HTML tags.

Before:
![image](https://user-images.githubusercontent.com/20326645/72565601-2f5fd380-3880-11ea-8712-db0cdffdafd2.png)

After:
![image](https://user-images.githubusercontent.com/20326645/72565653-53231980-3880-11ea-992a-196de98d2035.png)

Signed-off-by: David Kwon <dakwon@redhat.com>