### PR TITLE
Add Qute TextMate grammar and language configuration for JSON, YAML and txt files

### DIFF
--- a/language-support/qute/qute-json.tmLanguage.json
+++ b/language-support/qute/qute-json.tmLanguage.json
@@ -1,0 +1,29 @@
+{
+  "name": "Qute JSON",
+  "injections": {
+    "L:support.type.property-name.json, L:string.quoted.double.json": {
+      "patterns": [
+        {
+          "include": "grammar.qute#templates"
+        },
+        {
+          "include": "grammar.qute#comment"
+        }
+      ]
+    },
+    "L:meta.structure.dictionary.json": {
+      "patterns": [
+        {
+          "include": "grammar.qute#comment"
+        }
+      ]
+    }
+  },
+  "patterns": [
+    {
+      "include": "source.json"
+    }
+  ],
+  "scopeName": "source.json.qute",
+  "uuid": "6c100627-887e-4550-82a8-a8b38084bfeb"
+}

--- a/language-support/qute/qute-txt.tmLanguage.json
+++ b/language-support/qute/qute-txt.tmLanguage.json
@@ -1,0 +1,10 @@
+{
+  "name": "Qute Text",
+  "patterns": [
+    {
+      "include": "grammar.qute"
+    }
+  ],
+  "scopeName": "text.qute",
+  "uuid": "753080cc-cfc9-4a1e-8f1b-f5c7d0fd5edc"
+}

--- a/language-support/qute/qute-yaml.tmLanguage.json
+++ b/language-support/qute/qute-yaml.tmLanguage.json
@@ -1,7 +1,7 @@
 {
-  "name": "Qute HTML",
+  "name": "Qute YAML",
   "injections": {
-    "L:meta.tag": {
+    "L:entity.name.tag.yaml, L:string.unquoted, L:string.quoted": {
       "patterns": [
         {
           "include": "grammar.qute#templates"
@@ -17,9 +17,9 @@
       "include": "grammar.qute"
     },
     {
-      "include": "text.html.basic"
+      "include": "source.yaml"
     }
   ],
-  "scopeName": "text.html.qute",
-  "uuid": "b4a8c279-6147-4ad0-8762-189dc6205546"
+  "scopeName": "source.yaml.qute",
+  "uuid": "3a51bb50-65bb-41e3-8d5b-d5af19b6f74d"
 }

--- a/language-support/qute/qute.tmLanguage.json
+++ b/language-support/qute/qute.tmLanguage.json
@@ -42,7 +42,7 @@
     },
     "section_start_tag": {
       "begin": "({)(#)(else\\sif|\\w+(\\.\\w+)*)",
-      "end": "(\\/)?((?<!\\\\)})",
+      "end": "(\\/)?((?<![\\s\\\\])})",
       "beginCaptures": {
         "1": {
           "name": "support.constant.handlebars"
@@ -70,7 +70,7 @@
     },
     "section_end_tag": {
       "begin": "({)(\\/)(\\w+(\\.\\w+)*)?\\s*",
-      "end": "((?<!\\\\)})",
+      "end": "((?<![\\s\\\\])})",
       "beginCaptures": {
         "1": {
           "name": "support.constant.handlebars"
@@ -93,8 +93,8 @@
       "name": "variable.parameter.function.qute"
     },
     "expression": {
-      "begin": "((?<!\\\\){)(?![!#@\\/])",
-      "end": "((?<!\\\\)})",
+      "begin": "((?<!\\\\){)(?![\\s!#@\\/])",
+      "end": "((?<![\\s\\\\])})",
       "beginCaptures": {
         "1": {
           "name": "support.constant.handlebars"
@@ -473,5 +473,5 @@
     }
   },
   "scopeName": "grammar.qute",
-  "uuid": "C011BB07-875D-4DEB-9582-0E1FEC0D1E4E"
+  "uuid": "7ba10786-68d6-4715-9a3e-bcbbda9854a1"
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
     "workspaceContains:**/src/main/resources/application.properties",
     "onLanguage:quarkus-properties",
     "onLanguage:java",
-    "onLanguage:qute-html"
+    "onLanguage:qute-html",
+    "onLanguage:qute-json",
+    "onLanguage:qute-yaml",
+    "onLanguage:qute-txt"
   ],
   "main": "./dist/extension",
   "extensionDependencies": [
@@ -68,6 +71,36 @@
         ],
         "extensions": [
           "qute.html"
+        ],
+        "configuration": "./language-support/qute/language-configuration.json"
+      },
+      {
+        "id": "qute-json",
+        "aliases": [
+          "Qute JSON"
+        ],
+        "extensions": [
+          "qute.json"
+        ],
+        "configuration": "./language-support/qute/language-configuration.json"
+      },
+      {
+        "id": "qute-yaml",
+        "aliases": [
+          "Qute YAML"
+        ],
+        "extensions": [
+          "qute.yaml"
+        ],
+        "configuration": "./language-support/qute/language-configuration.json"
+      },
+      {
+        "id": "qute-txt",
+        "aliases": [
+          "Qute Text"
+        ],
+        "extensions": [
+          "qute.txt"
         ],
         "configuration": "./language-support/qute/language-configuration.json"
       }
@@ -232,6 +265,21 @@
         "language": "qute-html",
         "scopeName": "text.html.qute",
         "path": "./language-support/qute/qute-html.tmLanguage.json"
+      },
+      {
+        "language": "qute-json",
+        "scopeName": "source.json.qute",
+        "path": "./language-support/qute/qute-json.tmLanguage.json"
+      },
+      {
+        "language": "qute-yaml",
+        "scopeName": "source.yaml.qute",
+        "path": "./language-support/qute/qute-yaml.tmLanguage.json"
+      },
+      {
+        "language": "qute-txt",
+        "scopeName": "text.qute",
+        "path": "./language-support/qute/qute-txt.tmLanguage.json"
       },
       {
         "scopeName": "grammar.qute",


### PR DESCRIPTION
fixes #182 

I will write some of my concerns about this PR tomorrow (mostly about how commenting should work).

For the time being, here are some quick demos:

*.qute.json:
![image](https://user-images.githubusercontent.com/20326645/72566895-b150fc00-3882-11ea-9d8f-378ef1f1d97c.png)

*.qute.yaml:
![image](https://user-images.githubusercontent.com/20326645/72567020-fffe9600-3882-11ea-8488-0461ee2e6d0b.png)

*.qute.txt:
![image](https://user-images.githubusercontent.com/20326645/72567233-79968400-3883-11ea-8453-68bc7cd9c7a6.png)

Signed-off-by: David Kwon <dakwon@redhat.com>