### PR TITLE
Add value validation severity preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,19 +55,20 @@ The following settings are supported:
 * `quarkus.tools.trace.server` : Trace the communication between VS Code and the Quarkus Language Server in the Output view.
 * `quarkus.tools.symbols.showAsTree` : Show Quarkus properties as tree (Outline). Default is `true`.
 * `quarkus.tools.validation.enabled` : Enables Quarkus validation. Default is `true`.
-* `quarkus.tools.validation.duplicate.severity` : Validation severity for duplicate Quarkus properties.
+* `quarkus.tools.validation.duplicate.severity` : Validation severity for duplicate properties for Quarkus/MicroProfile `*.properties` files.
 Default is `warning`.
-* `quarkus.tools.validation.syntax.severity` : Validation severity for Quarkus property syntax checking.
+* `quarkus.tools.validation.syntax.severity` : Validation severity for property syntax checking for Quarkus/MicroProfile `*.properties` files.
 Default is `error`.
-* `quarkus.tools.validation.required.severity` : Validation severity for required Quarkus properties.
+* `quarkus.tools.validation.required.severity` : Validation severity for required properties for Quarkus/MicroProfile `*.properties` files.
 Default is `none`.
-* `quarkus.tools.validation.unknown.severity` : Validation severity for unknown Quarkus properties. Default is `warning`.
+* `quarkus.tools.validation.unknown.severity` : Validation severity for unknown properties for Quarkus/MicroProfile `*.properties` files. Default is `warning`.
 * `quarkus.tools.validation.unknown.excluded` : Array of properties to ignore for unknown Quarkus properties validation. Patterns can be used ('*' = any string, '?' = any character). Default is `[]`.
 
 
 Since 1.3.0:
 * `quarkus.tools.codeLens.urlCodeLensEnabled` : Enable/disable the URL code lenses for REST services. Default is`true`.
 * `quarkus.tools.starter.showExtensionDescriptions`: Determines whether to show the Quarkus extension descriptions when selecting Quarkus extensions. Default is `true`.
+* `quarkus.tools.validation.value.severity`: Validation severity for property values for Quarkus/MicroProfile `*.properties` files. Default is `error`.
 
 ## Articles
 

--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
             "error"
           ],
           "default": "warning",
-          "description": "Validation severity for duplicate Quarkus properties.",
+          "markdownDescription": "Validation severity for duplicate properties for Quarkus/MicroProfile `*.properties` files.",
           "scope": "window"
         },
         "quarkus.tools.validation.required.severity": {
@@ -227,7 +227,7 @@
             "error"
           ],
           "default": "none",
-          "description": "Validation severity for required Quarkus properties.",
+          "markdownDescription": "Validation severity for required properties for Quarkus/MicroProfile `*.properties` files.",
           "scope": "window"
         },
         "quarkus.tools.validation.unknown.severity": {
@@ -238,7 +238,7 @@
             "error"
           ],
           "default": "warning",
-          "description": "Validation severity for unknown Quarkus properties.",
+          "markdownDescription": "Validation severity for unknown properties for Quarkus/MicroProfile `*.properties` files.",
           "scope": "window"
         },
         "quarkus.tools.validation.syntax.severity": {
@@ -249,7 +249,18 @@
             "error"
           ],
           "default": "error",
-          "description": "Validation severity for Quarkus property syntax checking.",
+          "markdownDescription": "Validation severity for property syntax checking for Quarkus/MicroProfile `*.properties` files",
+          "scope": "window"
+        },
+        "quarkus.tools.validation.value.severity": {
+          "type": "string",
+          "enum": [
+            "none",
+            "warning",
+            "error"
+          ],
+          "default": "error",
+          "markdownDescription": "Validation severity for property values for Quarkus/MicroProfile `*.properties` files.",
           "scope": "window"
         },
         "quarkus.tools.validation.unknown.excluded": {


### PR DESCRIPTION
I realized that this is the most easiest way to fix #201.

No changes in microprofile-ls is required. In order to disable value validation, this PR introduces a new preference called `quarkus.tools.validation.value.severity`. Value validation is disabled by setting the severity to `none`


Signed-off-by: David Kwon <dakwon@redhat.com>