### PR TITLE
Add preview tag to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "icon": "icons/logo.png",
   "author": "Red Hat",
   "publisher": "redhat",
+  "preview": true,
   "license": "Apache-2.0",
   "bugs": "https://github.com/redhat-developer/vscode-quarkus/issues",
   "engines": {


### PR DESCRIPTION
This change is needed as all the extensions in VSCode Marketplace supported by Red Hat should be in Preview state.