### PR TITLE
Edit TextMate grammar to allow whitespaces before braces

### DIFF
--- a/language-support/qute/qute.tmLanguage.json
+++ b/language-support/qute/qute.tmLanguage.json
@@ -42,7 +42,7 @@
     },
     "section_start_tag": {
       "begin": "({)(#)(else\\sif|\\w+(\\.\\w+)*)",
-      "end": "(\\/)?((?<![\\s\\\\])})",
+      "end": "(\\/)?((?<![\\\\])})",
       "beginCaptures": {
         "1": {
           "name": "support.constant.handlebars"
@@ -70,7 +70,7 @@
     },
     "section_end_tag": {
       "begin": "({)(\\/)(\\w+(\\.\\w+)*)?\\s*",
-      "end": "((?<![\\s\\\\])})",
+      "end": "((?<![\\\\])})",
       "beginCaptures": {
         "1": {
           "name": "support.constant.handlebars"
@@ -94,7 +94,7 @@
     },
     "expression": {
       "begin": "((?<!\\\\){)(?![\\s!#@\\/])",
-      "end": "((?<![\\s\\\\])})",
+      "end": "((?<![\\\\])})",
       "beginCaptures": {
         "1": {
           "name": "support.constant.handlebars"


### PR DESCRIPTION
Fixes #221 

The syntax highlighting does not break when there are whitespaces before the closing brace
![image](https://user-images.githubusercontent.com/20326645/77557367-0ff0b280-6e90-11ea-9504-3e6e61721089.png)

Signed-off-by: David Kwon <dakwon@redhat.com>