### PR TITLE
Improve application.properties textmate grammar

### DIFF
--- a/language-support/properties-support/java-properties.tmLanguage.json
+++ b/language-support/properties-support/java-properties.tmLanguage.json
@@ -1,15 +1,89 @@
 {
-  "fileTypes": [
-    "properties"
+  "information_for_contributors": [
+    "This file was referenced from https://github.com/microsoft/vscode/blob/master/extensions/ini/syntaxes/ini.tmLanguage.json",
+    "This file has been edited to fit the needs for java.properties syntax highlighting"
   ],
-  "foldingStartMarker": "^[a-zA-Z0-9.-_]+=.*\\\n",
-  "foldingStopMarker": "^(.*(?<!\\)\n)",
-  "keyEquivalent": "^~J",
+  "name": "Java Properties",
+  "scopeName": "source.java-properties",
   "patterns": [
     {
-      "include": "source.ini"
+      "comment": "Matching for comments that start with #",
+      "begin": "(^[ \\t]+)?(?=#)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.whitespace.comment.leading.java-properties"
+        }
+      },
+      "end": "(?!\\G)",
+      "patterns": [
+        {
+          "begin": "#",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.java-properties"
+            }
+          },
+          "end": "\\n",
+          "name": "comment.line.number-sign.java-properties"
+        }
+      ]
+    },
+    {
+      "comment": "Matching for property keys",
+      "captures": {
+        "1": {
+          "name": "keyword.other.definition.java-properties"
+        },
+        "4": {
+          "name": "punctuation.separator.key-value.java-properties"
+        }
+      },
+      "match": "^\\s*([\\/a-zA-Z0-9%_.-]+)\\s*(?=[=\\\\])"
+    },
+    {
+      "comment": "Matching the equals sign and property value",
+      "begin": "=",
+      "end": "(?<!\\\\)\\n",
+      "patterns": [
+        {
+          "include": "#numbers"
+        }
+      ]
+    },
+    {
+      "comment": "Matching for section (text enclosed between square brackets [])",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.entity.java-properties"
+        },
+        "4": {
+          "name": "punctuation.definition.entity.java-properties"
+        }
+      },
+      "match": "^(\\[)(.*?)(\\])",
+      "name": "entity.name.section.group-title.java-properties"
     }
   ],
-  "scopeName": "source.ini.properties",
-  "uuid": "D364E829-7643-4AFF-948D-3C0D6B4EA8A4"
+  "repository": {
+    "numbers": {
+      "patterns": [
+        {
+          "match": "(?x)\n\\b(?<!\\$)\n0(x|X)\n(\n  (?<!\\.)[0-9a-fA-F]([0-9a-fA-F_]*[0-9a-fA-F])?[Ll]?(?!\\.)\n  |\n  (\n    [0-9a-fA-F]([0-9a-fA-F_]*[0-9a-fA-F])?\\.?\n    |\n    ([0-9a-fA-F]([0-9a-fA-F_]*[0-9a-fA-F])?)?\\.[0-9a-fA-F]([0-9a-fA-F_]*[0-9a-fA-F])?\n  )\n  [Pp][+-]?[0-9]([0-9_]*[0-9])?[FfDd]?\n)\n\\b(?!\\$)",
+          "name": "constant.numeric.hex.java-properties"
+        },
+        {
+          "match": "\\b(?<!\\$)0(b|B)[01]([01_]*[01])?[Ll]?\\b(?!\\$)",
+          "name": "constant.numeric.binary.java-properties"
+        },
+        {
+          "match": "\\b(?<!\\$)0[0-7]([0-7_]*[0-7])?[Ll]?\\b(?!\\$)",
+          "name": "constant.numeric.octal.java-properties"
+        },
+        {
+          "match": "(?x)\n(?<!\\$)\n(\n  \\b[0-9]([0-9_]*[0-9])?\\.\\B(?!\\.)\n  |\n  \\b[0-9]([0-9_]*[0-9])?\\.([Ee][+-]?[0-9]([0-9_]*[0-9])?)[FfDd]?\\b\n  |\n  \\b[0-9]([0-9_]*[0-9])?\\.([Ee][+-]?[0-9]([0-9_]*[0-9])?)?[FfDd]\\b\n  |\n  \\b[0-9]([0-9_]*[0-9])?\\.([0-9]([0-9_]*[0-9])?)([Ee][+-]?[0-9]([0-9_]*[0-9])?)?[FfDd]?\\b\n  |\n  (?<!\\.)\\B\\.[0-9]([0-9_]*[0-9])?([Ee][+-]?[0-9]([0-9_]*[0-9])?)?[FfDd]?\\b\n  |\n  \\b[0-9]([0-9_]*[0-9])?([Ee][+-]?[0-9]([0-9_]*[0-9])?)[FfDd]?\\b\n  |\n  \\b[0-9]([0-9_]*[0-9])?([Ee][+-]?[0-9]([0-9_]*[0-9])?)?[FfDd]\\b\n  |\n  \\b(0|[1-9]([0-9_]*[0-9])?)(?!\\.)[Ll]?\\b\n)\n(?!\\$)",
+          "name": "constant.numeric.decimal.java-properties"
+        }
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -286,12 +286,12 @@
     "grammars": [
       {
         "language": "microprofile-properties",
-        "scopeName": "source.ini.properties",
+        "scopeName": "source.java-properties",
         "path": "./language-support/properties-support/java-properties.tmLanguage.json"
       },
       {
         "language": "quarkus-properties",
-        "scopeName": "source.ini.properties",
+        "scopeName": "source.java-properties",
         "path": "./language-support/properties-support/java-properties.tmLanguage.json"
       },
       {


### PR DESCRIPTION
Fixes #233 

The PR https://github.com/textmate/ini.tmbundle/pull/1 that fixes this apostrophe problem:
![image](https://user-images.githubusercontent.com/20326645/77585045-3a576580-6eba-11ea-9aea-47b39a6accac.png)

uses the `\K` regex pattern, which VS Code does not seem to support: https://github.com/microsoft/vscode/issues/93426

Therefore in VS Code, the regexes with `\K` in that PR does not match with anything, therefore does not highlight anything in orange, therefore appearing to solve the issue in VS Code.

The PR I am making right now, contains TextMate grammar from https://github.com/microsoft/vscode/blob/master/extensions/ini/syntaxes/ini.tmLanguage.json, removes source ini specific grammar (like using `;` for commenting), removes matching the single or double quotes (which removes the orange string highlighting alltogether), and adds support for multi-line property keys and number highlighting.

Examples:
```
quarkus\
.application\
.name=name

quarkus.application.version=123
```
![image](https://user-images.githubusercontent.com/20326645/77586140-0b41f380-6ebc-11ea-8117-4a5c5d816c3d.png)


```
quarkus.application.name=long\
application\
name

quarkus.http.port = 1234
```
![image](https://user-images.githubusercontent.com/20326645/77586157-12690180-6ebc-11ea-8fa3-9df2852a4ce8.png)


```
quarkus.application.name=David's application
quarkus.http.port=8080
```
![image](https://user-images.githubusercontent.com/20326645/77586169-16951f00-6ebc-11ea-8ec8-1eebce0ac377.png)


```
org.acme.restclient.CountriesService/mp-rest/url=https://restcountries.eu/rest
configKey/mp-rest/url = 
```
![image](https://user-images.githubusercontent.com/20326645/77586188-1dbc2d00-6ebc-11ea-9d0b-1c0320b7114e.png)


```
# comment
quarkus.\
http.\
port = { \
  "name": "EpochMillis" \
}

# comment
quarkus.application.name=my app name
```
![image](https://user-images.githubusercontent.com/20326645/77586196-20b71d80-6ebc-11ea-98eb-ad0fa6f83d4f.png)


Signed-off-by: David Kwon <dakwon@redhat.com>