### PR TITLE
Show groupId and artifactId in extensions picker

### DIFF
--- a/src/wizards/generateProject/ExtensionsPicker.ts
+++ b/src/wizards/generateProject/ExtensionsPicker.ts
@@ -219,9 +219,16 @@ export class ExtensionsPicker {
     }
 
     items = items.concat(this.selectedExtensions.concat(this.unselectedExtensions).map((it: QExtension) => {
+      let description: string;
+      if (this.showDescription) {
+        description = (it.isRequired ? ' (This is a required extension)' : ` (${it.groupId}:${it.artifactId})`);
+      } else {
+        description = it.category;
+      }
+      
       const quickPickItem: QuickPickExtensionItem = {
         type: Type.Extension,
-        description: it.category + (it.isRequired ? ' - (This is a required extension)' : ''),
+        description,
         label: `${this.isSelected(it) ? '$(check) ' : ''}${it.name}`,
         extension: it
       };


### PR DESCRIPTION
Fixes #197

Demo:
![](https://raw.githubusercontent.com/xorye/gifs/master/new_issues/extension_picker/picker.gif?token=AE3CR5O6HBR3D6FDMRYJBYK6RJHHO)

Signed-off-by: David Kwon <dakwon@redhat.com>