### PR TITLE
Use RHEL 8 instead for RHEL 7 to workaround bug in VS Code 1.46.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('rhel7'){
+node('rhel8'){
     stage('Checkout repos') {
         deleteDir()
         def hasServerDir = fileExists 'quarkus-ls'


### PR DESCRIPTION
on RHEL 7, the test stays blocked forever. See
https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/VS%20Code/job/vscode-quarkus-release/331

see microsoft/vscode#99492 and
https://issues.redhat.com/browse/FUSETOOLS2-490

Signed-off-by: Aurélien Pupier <apupier@redhat.com>