### PR TITLE
Display project name when adding extensions

### DIFF
--- a/src/definitions/ProjectLabelInfo.ts
+++ b/src/definitions/ProjectLabelInfo.ts
@@ -21,10 +21,12 @@ import { WORKSPACE_LABELS_COMMAND_ID } from "./constants";
 
 export class ProjectLabelInfo {
   uri: string;
+  name: string;
   labels: ProjectLabel[];
-  constructor(uri: string, labels: ProjectLabel[]) {
+  constructor(uri: string, name: string, labels: ProjectLabel[]) {
     this.uri = uri;
     this.labels = labels;
+    this.name = name;
   }
 
   public getBuildSupport(): BuildSupport|undefined {
@@ -54,9 +56,9 @@ export class ProjectLabelInfo {
   }
 
   public static async getWorkspaceProjectLabelInfo(): Promise<ProjectLabelInfo[]> {
-    const projectLabels: {uri: string, labels: ProjectLabel[]}[] = await commands.executeCommand("java.execute.workspaceCommand", WORKSPACE_LABELS_COMMAND_ID);
+    const projectLabels: {uri: string, name: string, labels: ProjectLabel[]}[] = await commands.executeCommand("java.execute.workspaceCommand", WORKSPACE_LABELS_COMMAND_ID);
     return projectLabels.map((p) => {
-      return new ProjectLabelInfo(p.uri, p.labels);
+      return new ProjectLabelInfo(p.uri, p.name, p.labels);
     });
   }
 }

--- a/src/utils/workspaceUtils.ts
+++ b/src/utils/workspaceUtils.ts
@@ -28,7 +28,7 @@ export async function getFilePathsFromFolder(folderPath: string, glob: string): 
  * Returns an array of `ProjectTypeInfo` containing information for each project
  * in the current workspace
  *
- * @param projectLabel optioanlly specify what project label to retrieve
+ * @param projectLabel optionally specify what project label to retrieve
  */
 export async function getWorkspaceProjectLabels(projectLabel?: ProjectLabel): Promise<ProjectLabelInfo[]> {
   const result: ProjectLabelInfo[] = await ProjectLabelInfo.getWorkspaceProjectLabelInfo();

--- a/src/wizards/getQuarkusProject.ts
+++ b/src/wizards/getQuarkusProject.ts
@@ -87,7 +87,7 @@ async function getProjectQuickPickItems(quarkusProjectFolders: ProjectLabelInfo[
   return quarkusProjectFolders.map((projectInfo) => {
     return {
       detail: projectInfo.uri,
-      label: path.basename(projectInfo.uri),
+      label: projectInfo.name,
       projectLabelInfo: projectInfo
     };
   });


### PR DESCRIPTION
When picking which project to add more extensions to when
you have multiple projects in the same workspace,
the name of the project is now displayed,
instead of just the name of the folder that the project is in.

Fixes #215

Signed-off-by: David Thompson <davthomp@redhat.com>