### PR TITLE
Notification when languageID is forced

### DIFF
--- a/src/QuarkusConfig.ts
+++ b/src/QuarkusConfig.ts
@@ -67,8 +67,12 @@ export namespace QuarkusConfig {
     saveToQuarkusConfig(DEBUG_TERMINATE_ON_EXIT, value);
   }
 
-  export function saveToQuarkusConfig<T>(configName: string, value: T) {
-    workspace.getConfiguration().update(configName, value, ConfigurationTarget.Global);
+  export function setPropertiesLanguageMismatch(value: PropertiesLanguageMismatch): Thenable<void> {
+    return saveToQuarkusConfig(PROPERTIES_LANGUAGE_MISMATCH, value);
+  }
+
+  export function saveToQuarkusConfig<T>(configName: string, value: T): Thenable<void> {
+    return workspace.getConfiguration().update(configName, value, ConfigurationTarget.Global);
   }
 }
 


### PR DESCRIPTION
Provides a notification when the user tries to switch the language ID of the properties file, and provides a 'Configure' button that navigates to the `quarkus.tools.propertiesLanguageMismatch` setting.

Closes #285

Signed-off-by: David Thompson <davthomp@redhat.com>