### PR TITLE
Display extension status on Quarkus welcome page.

### DIFF
--- a/assets/webviews/styles/welcome.css
+++ b/assets/webviews/styles/welcome.css
@@ -7,7 +7,12 @@ h2 {
 
 .title-header {
   font-size: 26px;
-  margin-bottom: 12px;
+}
+
+.title-wrapper {
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px; /* This is from .title-header */
 }
 
 .no-bottom-margin {
@@ -31,4 +36,16 @@ h2 {
 #showWhenUsingQuarkusTools {
   vertical-align: middle;
   margin-left: 0px;
+}
+
+/* See vscode extensionEditor.css */
+.preview {
+	background: rgb(214, 63, 38);
+	font-size: 10px;
+	font-style: italic;
+	margin-left: 10px;
+	padding: 3px 4px;
+	border-radius: 4px;
+	user-select: none;
+	-webkit-user-select: none;
 }

--- a/assets/webviews/templates/welcome.ejs
+++ b/assets/webviews/templates/welcome.ejs
@@ -11,7 +11,12 @@
 
 <body>
   <div class="section-div">
-    <h2 class="title-header">Quarkus Tools for <%= appName %></h2>
+    <div class="title-wrapper">
+      <h2 class="title-header">Quarkus Tools for <%= appName %></h2>
+      <% if (status) { %>
+        <span class="preview"><%= status %></span>
+      <% } %>
+    </div>
     <p class="no-bottom-margin">Welcome! This extension provides tools to get you up and running with Quarkus application development in <%= appName %>.</p>
     <p class="no-bottom-margin">Both Maven and Gradle Quarkus projects are supported.</p>
   </div>

--- a/src/webviews/WelcomeWebview.ts
+++ b/src/webviews/WelcomeWebview.ts
@@ -75,6 +75,7 @@ export class WelcomeWebview {
   private async getWebviewContent(): Promise<string> {
 
     const htmlTemplatePath: string = this.getHtmlTemplateUri().fsPath;
+    const extensionStatus: string = vscode.extensions.getExtension('redhat.vscode-quarkus').packageJSON.preview ? 'Preview' : '';
 
     const data = {
       appName: vscode.env.appName,
@@ -82,6 +83,7 @@ export class WelcomeWebview {
       cssUri: this.getCssUri(),
       cspSource: this._panel.webview.cspSource,
       jsUri: this.getJsUri(),
+      status: extensionStatus,
     };
 
     return await new Promise((resolve: any, reject: any): any => {


### PR DESCRIPTION
- Resolves #219

Is there a property for an experimental or stable extension ? The only property I could find was `preview`, which only causes the 'Preview' highlighted term to show up beside the extension's name.