### PR TITLE
Check for execution property before inspecting task

### DIFF
--- a/src/utils/tasksUtils.ts
+++ b/src/utils/tasksUtils.ts
@@ -68,7 +68,8 @@ async function getTasksFromWorkspace(workspaceFolder: WorkspaceFolder): Promise<
 function isQuarkusDevTask(task: Task, projectBuildSupport: BuildSupport): boolean {
 
   const execution: ProcessExecution | ShellExecution = task.execution;
-  return 'commandLine' in execution &&
+  return execution &&
+    'commandLine' in execution &&
     (execution.commandLine.includes(projectBuildSupport.getDefaultExecutable()) ||
     execution.commandLine.includes(projectBuildSupport.getWrapper()) ||
     execution.commandLine.includes(projectBuildSupport.getWrapperWindows()));


### PR DESCRIPTION
When [Project Manager for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-dependency) is installed alongside Quarkus Tooks, running `Quarkus: Debug current Quarkus project` task basically does nothing. This is because Project Manager for Java exposes a Task that has no `execution` property, so that the call to  `src/utils/tasksUtils.ts#isQuarkusDevTask()` throws an exception.

Fixes #324 