### PR TITLE
Upgrade infrastructure to support GLIBCXX 3.4.21.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('rhel7'){
+node('rhel8'){
     stage('Checkout repos') {
         deleteDir()
         def hasLsp4mpDir = fileExists 'lsp4mp'


### PR DESCRIPTION
- Use rhel8 nodes instead of rhel7 on Jenkins infra

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>