### PR TITLE
Move "show welcome page" checkbox to the top of the welcome page.

### DIFF
--- a/assets/webviews/templates/welcome.ejs
+++ b/assets/webviews/templates/welcome.ejs
@@ -11,6 +11,10 @@
 
 <body>
   <div class="section-div">
+    <input type="checkbox" id="showWhenUsingQuarkusTools" <% if (checkboxValue) { %> checked <% } %>>
+    <label for="showWhenUsingQuarkusTools">Show welcome page when using Quarkus Tools</label>
+  </div>
+  <div class="section-div">
     <div class="title-wrapper">
       <h2 class="title-header">Quarkus Tools for <%= appName %></h2>
       <% if (status) { %>
@@ -74,10 +78,6 @@
         <a class="section-link" href="https://github.com/quarkusio/quarkus-quickstarts">View quickstart projects</a>
       </div>
     </div>
-  </div>
-  <div class="section-div">
-    <input type="checkbox" id="showWhenUsingQuarkusTools" <% if (checkboxValue) { %> checked <% } %>>
-    <label for="showWhenUsingQuarkusTools">Show welcome page when using Quarkus Tools</label>
   </div>
 </body>
 <script src="<%= jsUri %>"></script>


### PR DESCRIPTION
- Those wishing to ignore a welcome page would likely close it without
  scrolling to the bottom (if their window is kept smaller), so we
  should place the checkbox in a more visible area
- Fixes #328

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

I've though about this, and although I know that many welcome pages probably adopt the same format as the VSCode Welcome Page (place the "show welcome page on startup" checkbox at the bottom), I don't think this is the right approach.

If a user wants to ignore the welcome page, they aren't going to scroll to the bottom, and discover the checkbox. Therefore we should place it in a more visible location.