### PR TITLE
Prompt to use TypeScript specified in package.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,7 @@
       "out": true // set this to false to include "out" folder in search results
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-  "typescript.tsc.autoDetect": "off"
+  "typescript.tsc.autoDetect": "off",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "typescript.tsdk": "node_modules/typescript/lib",
 }


### PR DESCRIPTION
Enables a prompt which alerts the vscode-quarkus developer when the version of the TypeScript language server used by VS Code is not the one specified in the `package.json`.

Signed-off-by: David Thompson <davthomp@redhat.com>
