### PR TITLE
Add a command to build a binary of a Quarkus app

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following commands are supported for both Maven and Gradle Quarkus projects:
   * `Quarkus: Generate a Quarkus project`: Generate a Quarkus project, based on https://code.quarkus.io/
   * `Quarkus: Add extensions to current project`: Add Quarkus extensions to currently opened Quarkus project
   * `Quarkus: Debug current Quarkus project`: Launches the Maven `quarkus:dev` plugin or the Gradle `quarkusDev` command and automatically attaches a debugger
+  * `Quarkus: Build executable`: Launches Maven or Gradle with the correct arguments to build an executable of the application (requires GraalVM or Mandrel to be configured)
 
 ## Quarkus/MicroProfile `properties` Features
 

--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -15,6 +15,7 @@ vscode-quarkus has opt-in telemetry collection, provided by [vscode-commons](htt
     * "Quarkus: Debug current Quarkus project"
     * "Quarkus: Generate a Quarkus project"
     * "Quarkus: Welcome"
+    * "Quarkus: Build executable"
 
 ## How to opt in or out
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -383,6 +383,12 @@
       "integrity": "sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==",
       "dev": true
     },
+    "@types/which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
+      "dev": true
+    },
     "@types/yauzl": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
@@ -1693,6 +1699,15 @@
           "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g=",
           "dev": true
         },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
         "yargs": {
           "version": "3.32.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
@@ -1872,6 +1887,17 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "crypt": {
@@ -2965,7 +2991,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "1.2.5"
           },
           "dependencies": {
             "minimist": {
@@ -3122,7 +3148,7 @@
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
-            "minimist": "^1.2.0",
+            "minimist": "1.2.5",
             "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
@@ -3468,6 +3494,17 @@
         "ini": "^1.3.4",
         "is-windows": "^1.0.1",
         "which": "^1.2.14"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "glogg": {
@@ -8217,6 +8254,17 @@
             "ini": "^1.3.5",
             "kind-of": "^6.0.2",
             "which": "^1.3.1"
+          },
+          "dependencies": {
+            "which": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+              "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+              "dev": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            }
           }
         },
         "interpret": {
@@ -8364,10 +8412,9 @@
       }
     },
     "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -136,6 +136,10 @@
         "title": "Quarkus: Debug current Quarkus project"
       },
       {
+        "command": "quarkusTools.buildBinary",
+        "title": "Quarkus: Build executable"
+      },
+      {
         "command": "quarkusTools.welcome",
         "title": "Quarkus: Welcome"
       },
@@ -272,6 +276,7 @@
     "@types/request-promise": "^4.1.44",
     "@types/semver": "^6.2.0",
     "@types/vscode": "^1.37.0",
+    "@types/which": "^2.0.1",
     "@types/yauzl": "^2.9.1",
     "chai": "^4.2.0",
     "chai-fs": "^2.0.0",
@@ -301,6 +306,7 @@
     "lodash": "^4.17.21",
     "request": "^2.88.0",
     "request-promise": "^4.2.4",
+    "which": "^2.0.2",
     "yauzl": "^2.10.0"
   }
 }

--- a/src/buildSupport/BuildSupport.ts
+++ b/src/buildSupport/BuildSupport.ts
@@ -13,18 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as path from 'path';
 import * as findUp from 'find-up';
+import * as path from 'path';
 import { Uri, WorkspaceFolder } from 'vscode';
 import { FsUtils } from '../utils/fsUtils';
-import { TaskPattern } from './TaskPattern';
 import { formattedPathForTerminal } from '../utils/shellUtils';
 import { getFilePathsFromFolder } from '../utils/workspaceUtils';
+import { TaskPattern } from './TaskPattern';
 
 interface BuildSupportData {
   buildFile: string;
   defaultExecutable: string;
   quarkusDev: string;
+  quarkusBinary: string;
   wrapper: string;
   wrapperWindows: string;
   taskBeginsPattern: string;
@@ -56,6 +57,7 @@ export interface TerminalCommandOptions {
 }
 
 export abstract class BuildSupport {
+
   buildSupportData: BuildSupportData;
 
   constructor(buildSupportData: BuildSupportData) {
@@ -76,6 +78,13 @@ export abstract class BuildSupport {
    * @param options
    */
   public abstract getQuarkusDevCommand(folderPath: string, options?: TerminalCommandOptions): Promise<TerminalCommand>;
+
+  /**
+   * Returns a command that builds the Quarkus application into a binary
+   * @param folderPath
+   * @param options
+   */
+  public abstract getQuarkusBinaryCommand(folderPath: string, options?: TerminalCommandOptions): Promise<TerminalCommand>;
 
   /**
    * Returns an appropriate build tool command depending on `options` and `buildFilePath`
@@ -183,9 +192,18 @@ export abstract class BuildSupport {
     return this.buildSupportData.quarkusDev;
   }
 
+  public getQuarkusBinary(): string {
+    return this.buildSupportData.quarkusBinary;
+  }
+
   public getQuarkusDevTaskName(workspaceFolder: WorkspaceFolder, projectFolder: string): string {
     const relativePath: string =  path.relative(workspaceFolder.uri.fsPath, projectFolder);
-    return  this.buildSupportData.quarkusDev + (relativePath.length > 0 ? ` (${relativePath})` : '');
+    return this.buildSupportData.quarkusDev + (relativePath.length > 0 ? ` (${relativePath})` : '');
+  }
+
+  public getQuarkusBinaryTaskName(workspaceFolder: WorkspaceFolder, projectFolder: string): string {
+    const relativePath: string =  path.relative(workspaceFolder.uri.fsPath, projectFolder);
+    return this.buildSupportData.quarkusBinary + (relativePath.length > 0 ? ` (${relativePath})` : '');
   }
 
   public getDefaultExecutable(): string {

--- a/src/buildSupport/GradleBuildSupport.ts
+++ b/src/buildSupport/GradleBuildSupport.ts
@@ -23,6 +23,7 @@ export class GradleBuildSupport extends BuildSupport {
       buildFile: 'build.gradle',
       defaultExecutable: 'gradle',
       quarkusDev: 'quarkusDev',
+      quarkusBinary: 'buildNative',
       wrapper: 'gradlew',
       wrapperWindows: 'gradlew.bat',
       taskBeginsPattern: '^.*Starting a Gradle Daemon*',
@@ -49,4 +50,11 @@ export class GradleBuildSupport extends BuildSupport {
     const gradle: string = await this.getCommand(folderPath, options.buildFilePath, { windows: options.windows });
     return { command: [gradle, quarkusDev].join(' ') };
   }
+
+  public async getQuarkusBinaryCommand(folderPath: string, options?: TerminalCommandOptions): Promise<TerminalCommand> {
+    const quarkusBinary: string = `${this.getQuarkusBinary()} --console=plain`;
+    const gradle: string = await this.getCommand(folderPath, options.buildFilePath, { windows: options.windows });
+    return { command: [gradle, quarkusBinary].join(' ') };
+  }
+
 }

--- a/src/buildSupport/MavenBuildSupport.ts
+++ b/src/buildSupport/MavenBuildSupport.ts
@@ -17,11 +17,13 @@ import { formattedPathForTerminal } from '../utils/shellUtils';
 import { BuildSupport, TerminalCommand, TerminalCommandOptions } from "./BuildSupport";
 
 export class MavenBuildSupport extends BuildSupport {
+
   constructor() {
     super({
       buildFile: 'pom.xml',
       defaultExecutable: 'mvn',
       quarkusDev: 'quarkus:dev',
+      quarkusBinary: 'package -Pnative',
       wrapper: 'mvnw',
       wrapperWindows: 'mvnw.cmd',
       taskBeginsPattern: '^.*Scanning for projects...*',
@@ -46,7 +48,12 @@ export class MavenBuildSupport extends BuildSupport {
     const pomPath: string = options.buildFilePath ? `-f ${await formattedPathForTerminal(options.buildFilePath)}` : '';
     const mvn: string = await this.getCommand(folderPath, options && options.buildFilePath, { windows: options && options.windows });
     return { command: [mvn, this.getQuarkusDev(), pomPath].join(' ') };
+  }
 
+  public async getQuarkusBinaryCommand(folderPath: string, options?: TerminalCommandOptions): Promise<TerminalCommand> {
+    const pomPath: string = options.buildFilePath ? `-f ${await formattedPathForTerminal(options.buildFilePath)}` : '';
+    const mvn: string = await this.getCommand(folderPath, options && options.buildFilePath, { windows: options && options.windows });
+    return { command: [mvn, this.getQuarkusBinary(), pomPath].join(' ') };
   }
 
 }

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -5,6 +5,7 @@ import { requestStandardMode } from "../utils/requestStandardMode";
 import { sendCommandFailedTelemetry, sendCommandSucceededTelemetry } from "../utils/telemetryUtils";
 import { WelcomeWebview } from "../webviews/WelcomeWebview";
 import { addExtensionsWizard } from "../wizards/addExtensions/addExtensionsWizard";
+import { buildBinary } from "../wizards/binary/buildBinary";
 import { startDebugging } from "../wizards/debugging/startDebugging";
 import { generateProjectWizard } from "../wizards/generateProject/generationWizard";
 import { deployToOpenShift } from "../wizards/deployToOpenShift/deployToOpenShift";
@@ -43,6 +44,12 @@ export function registerVSCodeCommands(context: ExtensionContext): void {
    * Command for deploying current Quarkus project to OpenShift with OpenShift Connector
    */
   registerCommandWithTelemetry(context, VSCodeCommands.DEPLOY_TO_OPENSHIFT, withStandardMode(deployToOpenShift, "Deploying to OpenShift"));
+
+  /**
+   * Command for building a binary
+   */
+  registerCommandWithTelemetry(context, VSCodeCommands.BUILD_BINARY, withStandardMode(buildBinary, "Building a binary"));
+
 }
 
 /**

--- a/src/definitions/constants.ts
+++ b/src/definitions/constants.ts
@@ -19,6 +19,7 @@ export namespace VSCodeCommands {
   export const CREATE_PROJECT = 'quarkusTools.createProject';
   export const ADD_EXTENSIONS = 'quarkusTools.addExtension';
   export const DEBUG_QUARKUS_PROJECT = 'quarkusTools.debugQuarkusProject';
+  export const BUILD_BINARY = 'quarkusTools.buildBinary';
   export const QUARKUS_WELCOME = 'quarkusTools.welcome';
   export const DEPLOY_TO_OPENSHIFT = 'quarkusTools.deployToOpenShift';
 }

--- a/src/wizards/binary/buildBinary.ts
+++ b/src/wizards/binary/buildBinary.ts
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2021 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as fs from "fs-extra";
+import * as path from "path";
+import { env, Task, tasks, Uri, window, workspace, WorkspaceFolder } from "vscode";
+import { BuildSupport } from "../../buildSupport/BuildSupport";
+import { ProjectLabelInfo } from "../../definitions/ProjectLabelInfo";
+import { TaskCreator } from "../debugging/TaskCreator";
+import { getQuarkusProject } from "../getQuarkusProject";
+import which = require("which");
+
+const NATIVE_IMAGE_DOCS_URI: Uri = Uri.parse('https://quarkus.io/guides/building-native-image');
+
+const RUN_ANYWAYS = 'Run anyways';
+const DO_NOT_RUN = 'Don\'t run';
+const LEARN_MORE = 'Learn more...';
+
+/**
+ * Selects a quarkus project, then starts building a binary for it
+ *
+ * Prompts the user if GraalVM isn't detected
+ *
+ * @returns when the binary build task has been started
+ */
+export async function buildBinary(): Promise<void> {
+  const projectLabelInfo: ProjectLabelInfo = await getQuarkusProject();
+  if (!projectLabelInfo) {
+    return;
+  }
+  if (!hasNativeImageOnGraalVmHome() && !hasNativeImageOnJavaHome() && !await hasNativeImageOnPath()) {
+    const result = await window.showInformationMessage(
+      'Unable to locate the `native-image` binary, '
+      + 'meaning the binary build will likely fail. '
+      + 'Attempt to generate a binary anyways?',
+      DO_NOT_RUN, RUN_ANYWAYS, LEARN_MORE);
+    if (result === LEARN_MORE) {
+      env.openExternal(NATIVE_IMAGE_DOCS_URI);
+    }
+    if (result !== RUN_ANYWAYS) {
+      return;
+    }
+  }
+  try {
+    await buildBinaryFromProject(projectLabelInfo);
+  } catch (e) {
+    window.showErrorMessage(`${e}`);
+  }
+}
+
+/**
+ * Returns true if $GRAALVM_HOME/bin/native-image exists, and false otherwise
+ *
+ * @returns true if $GRAALVM_HOME/bin/native-image exists, and false otherwise
+ */
+function hasNativeImageOnGraalVmHome(): boolean {
+  return pathFromEnvHasNativeImage(process.env.GRAALVM_HOME);
+}
+
+/**
+ * Returns true if $JAVA_HOME/bin/native-image exists, and false otherwise
+ *
+ * @returns true if $JAVA_HOME/bin/native-image exists, and false otherwise
+ */
+function hasNativeImageOnJavaHome(): boolean {
+  return pathFromEnvHasNativeImage(process.env.JAVA_HOME);
+}
+
+function pathFromEnvHasNativeImage(envVarValue: string | undefined): boolean {
+  if (envVarValue && envVarValue.trim()) {
+    return fs.existsSync(path.join(envVarValue, 'bin', 'native-image'));
+  }
+  return false;
+}
+
+/**
+ * Returns true if `native-image` is on the path and false otherwise
+ *
+ * @returns true if `native-image` is on the path and false otherwise
+ */
+async function hasNativeImageOnPath(): Promise<boolean> {
+  try {
+    return !! await which('native-image');
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * Builds a binary of the given Quarkus project
+ *
+ * @returns when the native-image task has been started (not when it's completed)
+ */
+async function buildBinaryFromProject(projectLabelInfo: ProjectLabelInfo): Promise<void> {
+  const projectBuildSupport: BuildSupport = projectLabelInfo.getBuildSupport();
+  const workspaceFolder: WorkspaceFolder | undefined = workspace.getWorkspaceFolder(Uri.file(projectLabelInfo.uri));
+  if (!workspaceFolder) {
+    throw new Error('The project specified cannot be found in any of the open folders');
+  }
+  await findAndStartBinaryTask(workspaceFolder, projectLabelInfo.uri, projectBuildSupport);
+}
+
+/**
+ * Creates the native-image VS Code task if necessary, runs the task, then returns once the task is started
+ *
+ * @param workspaceFolder
+ * @param projectFolder
+ * @param quarkusBuildSupport
+ * @returns when the native-image task has been started (not when it's completed)
+ */
+async function findAndStartBinaryTask(
+  workspaceFolder: WorkspaceFolder,
+  projectFolder: string,
+  quarkusBuildSupport: BuildSupport): Promise<void> {
+  let nativeImageTasks = await getBinaryTasks(workspaceFolder, projectFolder, quarkusBuildSupport);
+  if (nativeImageTasks.length === 0) {
+    await TaskCreator.createTask(workspaceFolder, projectFolder, quarkusBuildSupport);
+    nativeImageTasks = await getBinaryTasks(workspaceFolder, projectFolder, quarkusBuildSupport);
+  } else if (nativeImageTasks.length > 1) {
+    console.error('More than one native-image tasks have been created. This likely means something went wrong with vscode-quarkus.');
+  }
+  tasks.executeTask(nativeImageTasks[0]);
+}
+
+/**
+ * Returns a list of all the VS Code tasks that build a binary
+ *
+ * @param workspaceFolder the vscode workspace folder
+ * @param projectFolder the quarkus project folder
+ * @param quarkusBuildSupport the quarkus build support
+ * @returns a list of all the VS Code tasks that build a binary
+ */
+async function getBinaryTasks(
+  workspaceFolder: WorkspaceFolder,
+  projectFolder: string,
+  quarkusBuildSupport: BuildSupport): Promise<Task[]> {
+  const registeredTasks: Task[] = await tasks.fetchTasks();
+  const nativeImageTasks: Task[] = registeredTasks.filter((task: Task) => {
+    return task.name && task.name === quarkusBuildSupport.getQuarkusBinaryTaskName(workspaceFolder, projectFolder);
+  });
+  return nativeImageTasks;
+}


### PR DESCRIPTION
* Adds a command that generates, then executes a `tasks.json` task that builds a binary
   * After you have used the command once, you can build a binary either through the command or `<Ctrl>+<Shift>+B` > Quarkus: Generate a binary
* The command checks to make sure GRAALVM_HOME is set before building the binary, and provides a link to the Quarkus docs if it's not set up.

This PR addresses one aspect of #335

Signed-off-by: David Thompson <davthomp@redhat.com>
