### PR TITLE
Mention required NodeJS 14.x in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,7 +220,7 @@ Here are some examples of the leveraging the extension point to provide Java cod
 ### Installation Prerequisites
 
   * [Visual Studio Code](https://code.visualstudio.com/)
-  * [Node.js](https://nodejs.org/en/)
+  * [Node.js 14.x](https://nodejs.org/en/)
   * [JDK 8+](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 
 ### Setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,7 +220,7 @@ Here are some examples of the leveraging the extension point to provide Java cod
 ### Installation Prerequisites
 
   * [Visual Studio Code](https://code.visualstudio.com/)
-  * [Node.js 14.x](https://nodejs.org/en/)
+  * [Node.js >= 10.x and <= 14.x](https://nodejs.org/en/)
   * [JDK 8+](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 
 ### Setup


### PR DESCRIPTION
When using NodeJS version higher than 14 `npm install` fails to install @nut-tree/opencv-build-linux package

Signed-off-by: Denis Golovin dgolovin@redhat.com