### PR TITLE
POC for avoiding waiting on vscode-microprofile

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   ],
   "main": "./dist/extension",
   "extensionDependencies": [
-    "redhat.vscode-microprofile",
     "redhat.java",
     "vscjava.vscode-java-debug",
     "redhat.vscode-commons"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import { ProjectLabelInfo } from './definitions/ProjectLabelInfo';
 import { PropertiesLanguageMismatch, QuarkusConfig } from './QuarkusConfig';
 import { QuarkusContext } from './QuarkusContext';
 import quarkusProjectListener from './QuarkusProjectListener';
+import { installMPExtOnStartup } from './requirements/toolsForMicroProfile';
 import { terminalCommandRunner } from './terminal/terminalCommandRunner';
 import { WelcomeWebview } from './webviews/WelcomeWebview';
 import { createTerminateDebugListener } from './wizards/debugging/terminateProcess';
@@ -34,6 +35,8 @@ export async function activate(context: ExtensionContext) {
   QuarkusContext.setContext(context);
   displayWelcomePageIfNeeded(context);
   commands.executeCommand('setContext', 'quarkusProjectExistsOrLightWeight', true);
+
+  installMPExtOnStartup();
 
   context.subscriptions.push(createTerminateDebugListener());
   quarkusProjectListener.getQuarkusProjectListener().then((disposableListener: Disposable) => {

--- a/src/requirements/toolsForMicroProfile.ts
+++ b/src/requirements/toolsForMicroProfile.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2021 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { extensions, window } from "vscode";
+import { QuarkusContext } from "../QuarkusContext";
+import { installExtension, isExtensionInstalled } from "../utils/extensionInstallationUtils";
+
+const TOOLS_FOR_MICRO_PROFILE_EXT = 'redhat.vscode-microprofile';
+
+const STARTUP_INSTALL_MEMO = 'mpExtInstallOnStartup.isIgnored';
+
+/**
+ * Prompts the user to install Tools for MicroProfile if they don't have it installed
+ *
+ * Allows the user to silence this prompt in the future by clicking on a button.
+ * Warns the user that only some functionality is available if they choose not to install vscode-microprofile.
+ *
+ * @returns when the user has installed Tools for MicroProfile,
+ *          or the user has chosen not to install Tools for MicroProfile,
+ *          or its detected that they've silenced this popup
+ */
+export async function installMPExtOnStartup(): Promise<void> {
+  if (isExtensionInstalled(TOOLS_FOR_MICRO_PROFILE_EXT)) {
+    return;
+  }
+  const installOnStartupIsIgnored = QuarkusContext.getExtensionContext().globalState.get(STARTUP_INSTALL_MEMO, false);
+  if (installOnStartupIsIgnored) {
+    return;
+  }
+  const YES = 'Install';
+  const NO = 'Don\'t install';
+  const NOT_AGAIN = 'Don\'t ask me again';
+  const result = await window.showWarningMessage('vscode-quarkus depends on Tools for MicroProfile for many of its features, '
+    + 'but can provide some functionality without it. '
+    + 'Install Tools for MicroProfile now? '
+    + 'You will need to reload the window after the installation.', YES, NO, NOT_AGAIN);
+  if (result === YES) {
+    try {
+      await installExtension(TOOLS_FOR_MICRO_PROFILE_EXT);
+    } catch (e) {
+      window.showErrorMessage(e);
+    }
+  } else if (result === NOT_AGAIN) {
+    QuarkusContext.getExtensionContext().globalState.update(STARTUP_INSTALL_MEMO, true);
+    limitedFunctionalityWarning();
+  } else {
+    limitedFunctionalityWarning();
+  }
+}
+
+/**
+ * Installs Tools for MicroProfile with the user's permission, in order to use a given command
+ *
+ * @param commandDescription description of the command that requires Tools for MicroProfile in order to be used
+ * @returns when the user refuses to install,
+ *          or when the install succeeds,
+ *          or when the install fails
+ */
+export async function installMPExtForCommand(commandDescription: string) {
+  const YES = 'Install';
+  const NO = `Cancel ${commandDescription}`;
+  const result = await window.showWarningMessage(`${commandDescription} requires Tools for MicroProfile. Install it now? `
+    + 'You will need to reload the window after the installation.',
+    YES, NO);
+  if (result === YES) {
+    try {
+      await installExtension(TOOLS_FOR_MICRO_PROFILE_EXT);
+    } catch (e) {
+      window.showErrorMessage(e);
+    }
+  } else {
+    window.showErrorMessage(`${commandDescription} requires Tools for MicroProfile, so it can't be run.`);
+  }
+}
+
+/**
+ * Returns true if Tools for MicroProfile is installed, and false otherwise
+ *
+ * @returns true if Tools for MicroProfile is installed, and false otherwise
+ */
+ export function isToolsForMicroProfileInstalled(): boolean {
+  return isExtensionInstalled(TOOLS_FOR_MICRO_PROFILE_EXT);
+}
+
+/**
+ * Returns when Tools for MicroProfile has started
+ *
+ * @returns when Tools for MicroProfile has started
+ */
+export async function microProfileToolsStarted(): Promise<void> {
+  await extensions.getExtension(TOOLS_FOR_MICRO_PROFILE_EXT).activate();
+}
+
+async function limitedFunctionalityWarning(): Promise<void> {
+  await window.showInformationMessage('vscode-quarkus will run with limited functionality');
+}

--- a/src/utils/extensionInstallationUtils.ts
+++ b/src/utils/extensionInstallationUtils.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2021 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { commands, Disposable, extensions } from "vscode";
+
+/**
+ * Error that is throw when the extension download times out
+ */
+export const EXT_DOWNLOAD_TIMEOUT_ERROR = new Error('Extension installation is taking a while');
+
+const DOWNLOAD_TIMEOUT = 60000;
+
+/**
+ * Installs the extension with the given id
+ *
+ * This function will timeout with an error if the installation takes a while.
+ * However, the extension installation will not be cancelled.
+ *
+ * @param extensionId the id (`"${publisher}.${name}"`) of the extension to check
+ * @returns when the extension is installed
+ * @throws `EXT_DOWNLOAD_TIMEOUT_ERROR` when the extension installation takes a while,
+ *         or a different error when the extension installation fails.
+ */
+export async function installExtension(extensionId: string): Promise<void> {
+  let installListenerDisposable: Disposable;
+  return new Promise<void>((resolve, reject) => {
+    installListenerDisposable = extensions.onDidChange(() => {
+      if (isExtensionInstalled(extensionId)) {
+        resolve();
+      }
+    });
+    commands.executeCommand("workbench.extensions.installExtension", extensionId)
+      .then((_unused: any) => { }, reject);
+    setTimeout(reject, DOWNLOAD_TIMEOUT, EXT_DOWNLOAD_TIMEOUT_ERROR);
+  }).finally(() => {
+    installListenerDisposable.dispose();
+  });
+}
+
+/**
+ * Returns true if the extension is installed and false otherwise
+ *
+ * @param extensionId the id (`"${publisher}.${name}"`) of the extension to check
+ * @returns `true` if the extension is installed and `false` otherwise
+ */
+export function isExtensionInstalled(extensionId: string): boolean {
+  return !!extensions.getExtension(extensionId);
+}

--- a/src/wizards/deployToOpenShift/deployToOpenShift.ts
+++ b/src/wizards/deployToOpenShift/deployToOpenShift.ts
@@ -15,7 +15,8 @@
  */
 import { Uri, window } from "vscode";
 import { ProjectLabelInfo } from "../../definitions/ProjectLabelInfo";
-import { deployQuarkusProject, getOpenShiftConnector, installOpenShiftConnectorWithProgress, isOpenShiftConnectorInstalled, OPENSHIFT_CONNECTOR } from "../../utils/openShiftConnectorUtils";
+import { isExtensionInstalled } from "../../utils/extensionInstallationUtils";
+import { deployQuarkusProject, getOpenShiftConnector, installOpenShiftConnectorWithProgress, OPENSHIFT_CONNECTOR, OPENSHIFT_CONNECTOR_EXTENSION_ID } from "../../utils/openShiftConnectorUtils";
 import { getQuarkusProject } from "../getQuarkusProject";
 
 /**
@@ -38,7 +39,7 @@ export async function deployToOpenShift(): Promise<void> {
  * @returns the OpenShift Connector extension API
  */
 async function installOpenShiftConnectorIfNeeded(): Promise<any> {
-  if (isOpenShiftConnectorInstalled()) {
+  if (isExtensionInstalled(OPENSHIFT_CONNECTOR_EXTENSION_ID)) {
     return getOpenShiftConnector();
   }
   return askToInstallOpenShiftConnector();
@@ -57,7 +58,7 @@ async function askToInstallOpenShiftConnector(): Promise<any> {
   if (response === YES) {
     try {
       await installOpenShiftConnectorWithProgress();
-      if (isOpenShiftConnectorInstalled()) {
+      if (isExtensionInstalled(OPENSHIFT_CONNECTOR_EXTENSION_ID)) {
         return getOpenShiftConnector();
       }
     } catch (e) {


### PR DESCRIPTION
Work in progress.

Instead of directly depending on vscode-microprofile, send the user a notification with a button to install the extension. The user can reject the installation. If they reject the installation, they will be free to use:
 * qute syntax highlight
 * properties file syntax highlight
 * project generator

However, no new language features (completion/validation) will appear, and they will be prompted to install vscode-microprofile when attempting to run commands that require it.

Since vscode-quarkus doesn't list itself as depending on vscode-microprofile anymore, it can start the project generator without starting vscode-microprofile ~~or even vscode-java~~. This allows for it to work in rootless mode.

Closes #323

Signed-off-by: David Thompson <davthomp@redhat.com>
