### PR TITLE
Consume vscode-microprofile API

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,6 @@
   "main": "./dist/extension",
   "extensionDependencies": [
     "redhat.vscode-microprofile",
-    "redhat.java",
-    "vscjava.vscode-java-debug",
     "redhat.vscode-commons"
   ],
   "contributes": {

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -8,6 +8,7 @@ import { addExtensionsWizard } from "../wizards/addExtensions/addExtensionsWizar
 import { startDebugging } from "../wizards/debugging/startDebugging";
 import { generateProjectWizard } from "../wizards/generateProject/generationWizard";
 import { deployToOpenShift } from "../wizards/deployToOpenShift/deployToOpenShift";
+import { toolsForMicroProfileReady } from "../utils/toolsForMicroProfileUtils";
 
 const NOT_A_QUARKUS_PROJECT = new Error('No Quarkus projects were detected in this folder');
 const STANDARD_MODE_REQUEST_FAILED = new Error('Error occurred while requesting standard mode from the Java language server');
@@ -89,15 +90,7 @@ async function registerCommandWithTelemetry(context: ExtensionContext, commandNa
  */
 function withStandardMode(commandAction: () => Promise<any>, commandDescription: string): () => Promise<void> {
   return async () => {
-    let isStandardMode = false;
-    try {
-      isStandardMode = await requestStandardMode(commandDescription);
-    } catch {
-      throw STANDARD_MODE_REQUEST_FAILED;
-    }
-    if (!isStandardMode) {
-      return;
-    }
+    await toolsForMicroProfileReady();
     let projectLabelInfo: ProjectLabelInfo[] = null;
     try {
       projectLabelInfo = await ProjectLabelInfo.getWorkspaceProjectLabelInfo();

--- a/src/utils/toolsForMicroProfileUtils.ts
+++ b/src/utils/toolsForMicroProfileUtils.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2021 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { extensions } from "vscode";
+
+const TOOLS_FOR_MICRO_PROFILE_ID = 'redhat.vscode-microprofile';
+
+/**
+ * Returns when lsp4mp is ready
+ *
+ * @returns when lsp4mp is ready
+ */
+export async function toolsForMicroProfileReady(): Promise<void> {
+  const api: ToolsForMicroProfileAPI = await extensions.getExtension(TOOLS_FOR_MICRO_PROFILE_ID).activate();
+  await api.languageServerReady();
+}
+
+interface ToolsForMicroProfileAPI {
+  languageServerReady(): Promise<void>;
+}


### PR DESCRIPTION
See redhat-developer/vscode-microprofile#58

Consume the API provided by vscode-microprofile in order to wait for lsp4mp to start when running commands that interact with lsp4mp.

Closes #323

Signed-off-by: David Thompson <davthomp@redhat.com>
