### PR TITLE
Recognize Quarkus per profile config files

### DIFF
--- a/language-support/properties-support/language-configuration.json
+++ b/language-support/properties-support/language-configuration.json
@@ -1,5 +1,5 @@
 // Referenced from:
-// https://github.com/spring-projects/sts4/blob/0714b6a69309789ac85441062698153b0ac4d9c6/vscode-extensions/vscode-spring-boot/properties-support/language-configuration.json 
+// https://github.com/spring-projects/sts4/blob/0714b6a69309789ac85441062698153b0ac4d9c6/vscode-extensions/vscode-spring-boot/properties-support/language-configuration.json
 
 {
 	"comments": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2977,7 +2977,6 @@
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3000,9 +2999,9 @@
           },
           "dependencies": {
             "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
               "dev": true,
               "optional": true
             }
@@ -3192,8 +3191,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3283,8 +3281,7 @@
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "onCommand:quarkusTools.createProject",
     "onCommand:quarkusTools.welcome",
     "workspaceContains:**/src/main/resources/application.properties",
+    "workspaceContains:**/src/main/resources/application-?*.properties",
     "workspaceContains:**src/main/resources/META-INF/microprofile-config.properties",
     "workspaceContains:**/src/main/resources/application.yaml",
     "workspaceContains:**/src/main/resources/application.yml",
@@ -72,11 +73,12 @@
     "languages": [
       {
         "id": "quarkus-properties",
+        "filenamePatterns": [
+          "application.properties",
+          "application-?*.properties"
+        ],
         "aliases": [
           "Quarkus properties"
-        ],
-        "filenames": [
-          "application.properties"
         ],
         "configuration": "./language-support/properties-support/language-configuration.json"
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -124,6 +124,8 @@ function tryToForceLanguageId(document: TextDocument, fileName: string, document
   });
 }
 
+const APP_PROPERTIES_PATTERN = /^application(?:-[A-Za-z]+)\.properties$/;
+
 /**
  * Update if required the language ID to 'quarkus-properties' if needed.
  *
@@ -138,7 +140,7 @@ async function updateLanguageId(document: TextDocument, documentCache: string[],
     return;
   }
   const fileName: string = path.basename(document.fileName);
-  if (fileName === 'application.properties') {
+  if (APP_PROPERTIES_PATTERN.test(fileName)) {
     if (document.languageId === 'quarkus-properties') {
       // the language ID is already quarkus-properties do nothing.
       return;


### PR DESCRIPTION
`application-*.properties` are now recognized as Quarkus Properties files, and will benefit from autocompletion of property keys and values.

See the language server side changes here: https://github.com/redhat-developer/quarkus-ls/pull/411

One portion of #371

Signed-off-by: David Thompson <davthomp@redhat.com>
