### PR TITLE
Clarify that Deploy to OpenShift uses `odo`

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
       },
       {
         "command": "quarkusTools.deployToOpenShift",
-        "title": "Quarkus: Deploy current Quarkus Project to OpenShift"
+        "title": "Quarkus: Deploy current Quarkus project to OpenShift (odo)"
       }
     ],
     "configuration": {


### PR DESCRIPTION
Closes #372

Signed-off-by: David Thompson <davthomp@redhat.com>
