### PR TITLE
Use `nc` parameter if available when generating project

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
         include:
-          - os: macos-latest
-            label: 'darwin'
           - os: ubuntu-latest
             label: 'linux'
     steps:

--- a/src/definitions/inputState.ts
+++ b/src/definitions/inputState.ts
@@ -34,7 +34,7 @@ export interface ProjectGenState extends State {
   packageName: string;
   resourceName: string;
   targetDir: Uri;
-  isGenerateSampleCode: boolean;
+  shouldGenerateCode: boolean;
 }
 
 export interface AddExtensionsState extends State {

--- a/src/test/vscodeUiTest/suite/projectGenerationTest.ts
+++ b/src/test/vscodeUiTest/suite/projectGenerationTest.ts
@@ -63,7 +63,7 @@ describe('Project generation tests', function() {
    * in the command palette
    */
   it('should open project generation wizard', async function() {
-    this.timeout(30000);
+    this.timeout(60000);
     const wizard: ProjectGenerationWizard = await ProjectGenerationWizard.openWizard(driver);
     expect(await wizardExists(), 'wizard did not open').to.be.true;
     await wizard.cancel();

--- a/src/utils/codeQuarkusApiUtils.ts
+++ b/src/utils/codeQuarkusApiUtils.ts
@@ -22,8 +22,20 @@ import { QuarkusConfig } from "../QuarkusConfig";
 
 const HTTP_MATCHER = new RegExp('^http://');
 
+/**
+ * Represents the capabilities of a Code Quarkus API, such as code.quarkus.io/api or code.quarkus.redhat.com/api
+ */
 export interface CodeQuarkusFunctionality {
-  canExcludeSampleCode: boolean;
+  /**
+   * This Code Quarkus API supports the `ne=...` parameter to specify that example code should not be generated
+   *
+   * @deprecated the `ne=...` parameter will be removed in favour of the `nc=...` parameter
+   */
+  supportsNoExamplesParameter: boolean;
+  /**
+   * This Code Quarkus API supports the `nc=...` to specify that starter code should not be generated
+   */
+  supportsNoCodeParameter: boolean;
 }
 
 /**
@@ -46,7 +58,8 @@ export async function getCodeQuarkusApiFunctionality(): Promise<CodeQuarkusFunct
   const openApiData: any = yaml.load(openApiYaml);
 
   return {
-    canExcludeSampleCode: openApiData?.paths?.['/api/download']?.get?.parameters?.filter(p => p?.name === 'ne').length > 0
+    supportsNoExamplesParameter: openApiData?.paths?.['/api/download']?.get?.parameters?.filter(p => p?.name === 'ne').length > 0,
+    supportsNoCodeParameter: openApiData?.paths?.['/api/download']?.get?.parameters?.filter(p => p?.name === 'nc').length > 0,
   } as CodeQuarkusFunctionality;
 }
 
@@ -57,7 +70,8 @@ export async function getCodeQuarkusApiFunctionality(): Promise<CodeQuarkusFunct
  */
 export function getDefaultFunctionality() {
   return {
-    canExcludeSampleCode: false
+    supportsNoExamplesParameter: false,
+    supportsNoCodeParameter: false,
   } as CodeQuarkusFunctionality;
 }
 


### PR DESCRIPTION
Checks the Code Quarkus openapi for the `nc` parameter. If it is available for the given Code Quarkus API, then it will pass `nc=true` to the project generation API when the user wants to exclude example code, instead of the deprecated `ne=true` parameter.

Addresses comments on #322

Signed-off-by: David Thompson <davthomp@redhat.com>
