### PR TITLE
Support termination of projects with no starter code.

### DIFF
--- a/src/buildSupport/GradleBuildSupport.ts
+++ b/src/buildSupport/GradleBuildSupport.ts
@@ -26,8 +26,8 @@ export class GradleBuildSupport extends BuildSupport {
       quarkusBinary: 'buildNative',
       wrapper: 'gradlew',
       wrapperWindows: 'gradlew.bat',
-      taskBeginsPattern: '^.*Starting a Gradle Daemon*',
-      taskEndsPattern: '^.*Quarkus .* started in .*\\. Listening on:*'
+      taskBeginsPattern: '^.*Task: ',
+      taskEndsPattern: '(^.*Quarkus .* started in .*\\.)|(^.* ERROR .* Failed to start)'
     });
   }
 

--- a/src/buildSupport/MavenBuildSupport.ts
+++ b/src/buildSupport/MavenBuildSupport.ts
@@ -26,8 +26,8 @@ export class MavenBuildSupport extends BuildSupport {
       quarkusBinary: 'package -Pnative',
       wrapper: 'mvnw',
       wrapperWindows: 'mvnw.cmd',
-      taskBeginsPattern: '^.*Scanning for projects...*',
-      taskEndsPattern: '^.*Quarkus .* started in .*\\. Listening on:*'
+      taskBeginsPattern: '^.*Scanning for projects...',
+      taskEndsPattern: '(^.*Quarkus .* started in .*\\.)|(^.* ERROR .* Failed to start)'
     });
   }
 


### PR DESCRIPTION
- Adjust task pattern to recognize build output when no starter code is
  present
- Fixes #389

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>