### PR TITLE
Use https as default value for the Quarkus starter project endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The following settings are supported:
 * All [microprofile.tools.* settings](https://github.com/redhat-developer/vscode-microprofile#supported-vs-code-settings) from the [Visual Studio Code extension for MicroProfile](https://github.com/redhat-developer/vscode-microprofile)
 * `quarkus.tools.debug.terminateProcessOnExit` : Determines whether to terminate the quarkus:dev task after closing the debug session. Default is `Ask`.
 * `quarkus.tools.alwaysShowWelcomePage` : Determines whether to show the welcome page on extension startup. Default is `true`.
-* `quarkus.tools.starter.api` : Quarkus API base URL. Default is `http://code.quarkus.io/api`.
+* `quarkus.tools.starter.api` : Quarkus API base URL. Default is `https://code.quarkus.io/api`.
 * `quarkus.tools.starter.showExtensionDescriptions`: Determines whether to show the Quarkus extension descriptions when selecting Quarkus extensions. Default is `true`.
 
 Since 1.6.0:

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
         },
         "quarkus.tools.starter.api": {
           "type": "string",
-          "default": "http://code.quarkus.io/api",
+          "default": "https://code.quarkus.io/api",
           "pattern": "https?://.+",
           "description": "Quarkus API base URL",
           "scope": "window"

--- a/src/test/vscodeUiTest/suite/projectGenerationTest.ts
+++ b/src/test/vscodeUiTest/suite/projectGenerationTest.ts
@@ -278,7 +278,6 @@ describe('Project generation tests', function () {
     const projectDestDir: string = path.join(tempDir, 'previous-values-extensions');
 
     const buildTool: string = 'Gradle';
-    const platformVersion: string = '2.2 (recommended)';
     const groupId: string = 'testgroupid';
     const artifactId: string = 'testartifactid';
     const projectVersion: string = 'testprojectVersion';
@@ -290,7 +289,6 @@ describe('Project generation tests', function () {
 
     await ProjectGenerationWizard.generateProject(driver, {
       buildTool,
-      platformVersion,
       groupId,
       artifactId,
       projectVersion,
@@ -317,7 +315,7 @@ describe('Project generation tests', function () {
     expect(await wizard.getNthQuickPickItemLabel(0)).equals(buildTool);
     await wizard.next();
 
-    expect(await wizard.getNthQuickPickItemLabel(0)).equals(platformVersion);
+    expect(await wizard.getNthQuickPickItemLabel(0)).contains("(recommended)");
     await wizard.next();
 
     const actualGroupId = await wizard.getText();

--- a/src/utils/codeQuarkusApiUtils.ts
+++ b/src/utils/codeQuarkusApiUtils.ts
@@ -21,8 +21,6 @@ import { URL } from "url";
 import { QuickPickItem } from "vscode";
 import { QuarkusConfig } from "../QuarkusConfig";
 
-const HTTP_MATCHER = new RegExp('^http://');
-
 /**
  * Represents the capabilities of a Code Quarkus API, such as code.quarkus.io/api or code.quarkus.redhat.com/api
  */
@@ -56,10 +54,8 @@ export interface CodeQuarkusFunctionality {
  * @throws if something goes wrong when getting the functionality from OpenAPI
  */
 export async function getCodeQuarkusApiFunctionality(): Promise<CodeQuarkusFunctionality> {
-  let oldOpenApiUrl: string = path.dirname(QuarkusConfig.getApiUrl()) + '/openapi';
-  let newOpenApiUrl: string = path.dirname(QuarkusConfig.getApiUrl()) + '/q/openapi';
-  oldOpenApiUrl = oldOpenApiUrl.replace(HTTP_MATCHER, "https://");
-  newOpenApiUrl = newOpenApiUrl.replace(HTTP_MATCHER, "https://");
+  const oldOpenApiUrl: string = path.dirname(QuarkusConfig.getApiUrl()) + '/openapi';
+  const newOpenApiUrl: string = path.dirname(QuarkusConfig.getApiUrl()) + '/q/openapi';
   let openApiYaml: string;
   try {
     openApiYaml = await httpsGet(newOpenApiUrl);
@@ -92,7 +88,7 @@ export function getDefaultFunctionality() {
  * @returns the available platform(s) for a Quarkus project from Code Quarkus API
  */
  export async function getCodeQuarkusApiPlatforms() {
-    const platformApiRes = await httpsGet((QuarkusConfig.getApiUrl() + '/streams').replace(HTTP_MATCHER, "https://"));
+    const platformApiRes = await httpsGet((QuarkusConfig.getApiUrl() + '/streams'));
     const availablePlatformsParsed = <Array<object>> yaml.load(platformApiRes);
     const availablePlatforms = availablePlatformsParsed.map(platform => {
       const version = `${platform["key"].split(":")[1]}${(platform["recommended"] ? ` (recommended)` : ``)}`;


### PR DESCRIPTION
- Fixes #402
- Use 'https://code.quarkus.io/api' as the default
- Respect 'quarkus.tools.starter.api', by not replacing 'http' with
  'https' if it has been set to something else

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>