### PR TITLE
Fix the npm-watch task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,22 +6,6 @@
     {
       "type": "npm",
       "script": "watch",
-      "problemMatcher": {
-        "owner": "typescript",
-        "pattern": [
-          {
-            "regexp": "\\[tsl\\] ERROR",
-            "file": 1,
-            "location": 2,
-            "message": 3
-          }
-        ],
-        "background": {
-          "activeOnStart": true,
-          "beginsPattern": "Compilation \\w+ starting…",
-          "endsPattern": "Compilation\\s+finished"
-        }
-      },
       "isBackground": true,
       "presentation": {
         "reveal": "never"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ node('rhel8'){
     }
 
     stage('Build') {
-        env.JAVA_HOME="${tool 'openjdk-1.8'}"
+        env.JAVA_HOME="${tool 'openjdk-11'}"
         env.PATH="${env.JAVA_HOME}/bin:${env.PATH}"
         dir ('vscode-quarkus') {
             sh "npm install --ignore-scripts"

--- a/package.json
+++ b/package.json
@@ -282,7 +282,7 @@
     "preinstall": "npx npm-force-resolutions",
     "vscode:prepublish": "webpack --mode production",
     "compile": "webpack --mode none",
-    "watch": "webpack --mode development --watch --info-verbosity verbose",
+    "watch": "webpack --mode development --watch",
     "test-compile": "tsc -p ./",
     "pretest": "npm run test-compile",
     "test": "node ./out/test/vscodeTest/runTest.js",


### PR DESCRIPTION
- Remove the no longer available --info-verbosity flag (since updating
  webpack-cli)
- Remove problemWatcher since we can no longer track compilation without
  the verbosity flag
- Also use a JDK 11 for builds now that we've updated to Tycho 2.x

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>