### PR TITLE
Temporarily work around regression in vscode-java for UI test suite.

### DIFF
--- a/src/test/vscodeUiTest/settings.json
+++ b/src/test/vscodeUiTest/settings.json
@@ -1,3 +1,4 @@
 {
-    "http.systemCertificates": false
+    "http.systemCertificates": false,
+    "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m -XX:HeapDumpPath=${HOME}"
 }


### PR DESCRIPTION
- Define HeapDumpPath to work around regression causing failure when no
  project workspace is defined

The issue is caused by https://github.com/redhat-developer/vscode-java/issues/2231

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>