### PR TITLE
Run vscode-quarkus build + test suite at fixed intervals

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,9 @@
 name: Tests
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '7 */8 * * *'
 jobs:
   tests:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
- With reliance on latest VS Code + Java releases, we should run the
  test suite more frequently to catch any regressions

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>