### PR TITLE
Changed direct index access highlighting

### DIFF
--- a/language-support/qute/qute.tmLanguage.json
+++ b/language-support/qute/qute.tmLanguage.json
@@ -481,7 +481,7 @@
               "name": "punctuation.separator.period.java"
             },
             "2": {
-              "name": "invalid.illegal.identifier.java"
+              "name": "constant.numeric.decimal.java"
             }
           }
         }


### PR DESCRIPTION
Changed direct index access highlighting to be consistent with standard highlighting.
![Screenshot from 2022-01-13 10-13-19](https://user-images.githubusercontent.com/26389510/149356552-39719531-b6ac-49df-a5c9-d8b44d282110.png)





Fixes #432 

Signed-off-by: Alexander Chen <alchen@redhat.com>