### PR TITLE
Report telemetry data from the project generation wizard.

### DIFF
--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -15,6 +15,9 @@ vscode-quarkus has opt-in telemetry collection, provided by [vscode-redhat-telem
     * "Quarkus: Debug current Quarkus project"
     * "Quarkus: Deploy current Quarkus project to OpenShift (odo)"
     * "Quarkus: Generate a Quarkus project"
+       * The project type (eg. Maven, Gradle, etc.)
+       * Whether sample code is to be included
+       * The list of Quarkus extensions selected
     * "Quarkus: Welcome"
     * "Quarkus: Build executable"
 

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -2,7 +2,7 @@ import { commands, ExtensionContext, window } from "vscode";
 import { VSCodeCommands } from "../definitions/constants";
 import { ProjectLabelInfo } from "../definitions/ProjectLabelInfo";
 import { requestStandardMode } from "../utils/requestStandardMode";
-import { sendCommandFailedTelemetry, sendCommandSucceededTelemetry } from "../utils/telemetryUtils";
+import { sendCommandFailedTelemetry, sendCommandSucceededTelemetry, sendTelemetry } from "../utils/telemetryUtils";
 import { WelcomeWebview } from "../webviews/WelcomeWebview";
 import { addExtensionsWizard } from "../wizards/addExtensions/addExtensionsWizard";
 import { buildBinary } from "../wizards/binary/buildBinary";
@@ -23,7 +23,7 @@ export function registerVSCodeCommands(context: ExtensionContext): void {
   /**
    * Command for creating a Quarkus project
    */
-  registerCommandWithTelemetry(context, VSCodeCommands.CREATE_PROJECT, generateProjectWizard);
+  registerCommandWithTelemetry(context, VSCodeCommands.CREATE_PROJECT, generateProjectWizard, true);
 
   /**
    * Command for adding Quarkus extensions to current Quarkus Maven project
@@ -63,12 +63,15 @@ export function registerVSCodeCommands(context: ExtensionContext): void {
  * @param context the extension context
  * @param commandName the name of the command to register
  * @param commandAction the async function to run when the command is called
+ * @param skipSuccess whether the success of the command should be reported
  */
-async function registerCommandWithTelemetry(context: ExtensionContext, commandName: string, commandAction: () => Promise<any>): Promise<void> {
+async function registerCommandWithTelemetry(context: ExtensionContext, commandName: string, commandAction: () => Promise<any>, skipSuccess?: boolean): Promise<void> {
   context.subscriptions.push(commands.registerCommand(commandName, async () => {
     try {
       await commandAction();
-      sendCommandSucceededTelemetry(commandName);
+      if (!skipSuccess) {
+        sendCommandSucceededTelemetry(commandName);
+      }
     } catch (e) {
       const msg = (e instanceof Error) ? e.message : e;
       window.showErrorMessage(msg);

--- a/src/utils/telemetryUtils.ts
+++ b/src/utils/telemetryUtils.ts
@@ -1,7 +1,7 @@
 import { getRedHatService, TelemetryService } from "@redhat-developer/vscode-redhat-telemetry/lib";
 import { ExtensionContext } from "vscode";
 
-const CMD_SUCCEED_VALUE = "succeeded";
+export const CMD_SUCCEED_VALUE = "succeeded";
 const CMD_FAIL_VALUE = "failed";
 
 let telemetryService: TelemetryService;
@@ -43,7 +43,6 @@ export async function sendCommandFailedTelemetry(commandName: string, msg?: stri
  * Send a telemetry event related to a given vscode-quarkus command
  *
  * @param commandName the name of the command that was run
- * @param suffix the suffix to add to the command to get the event name
  * @throws if the telemetry service has not been initialized yet
  * @returns when the telemetry event has been sent
  */
@@ -57,5 +56,22 @@ async function sendCommandTelemetry(commandName: string, succeeded: boolean, msg
       status: succeeded ? CMD_SUCCEED_VALUE : CMD_FAIL_VALUE,
       error_message: msg
     }
+  });
+}
+
+/**
+ * Send a telemetry event related to a given vscode-quarkus command
+ *
+ * @param commandName the name of the command that was run
+ * @throws if the telemetry service has not been initialized yet
+ * @returns when the telemetry event has been sent
+ */
+ export async function sendTelemetry(commandName: string, data: any): Promise<void> {
+  if (!isTelemetryInit) {
+    throw new Error('Telemetry has not been initialized yet');
+  }
+  await telemetryService.send({
+    name: commandName,
+    properties: data
   });
 }


### PR DESCRIPTION
- Fixes #405
- perform telemetry directly in the project generation wizard.
- Make deactivate() return an empty Promise to restore shutdown events

The project generation wizard has some cases where the `vscode.openFolder` command may be called. In those cases, the extension is shut down / disposed and the command never returns, so we aren't actually reporting this type of telemetry in certain cases! This means we can't do telemetry in the `registerCommandWithTelemetry` wrapper, and should do it just before the open folder logic.

Also, I'm not yet sure why, but having `deactivate()` return an empty Promise, restores the shutdown telemetry events for me, where before none were reported. Interestingly, the last reporting of a `shutdown` event for me happened on Dec 8th with VS Code 1.62.3. 1.63.0 was released the same day so it looks like the update might have changed something.

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>