### PR TITLE
Improved syntax coloration for Qute `in`

### DIFF
--- a/language-support/qute/qute.tmLanguage.json
+++ b/language-support/qute/qute.tmLanguage.json
@@ -362,6 +362,14 @@
         {
           "match": "\\b(const|goto)\\b",
           "name": "keyword.reserved.java"
+        },
+        {
+          "match": "\\b(is|as|eq|ne|gt|ge|lt|le)\\b",
+          "name": "keyword.control.operator"
+        },
+        {
+          "match": "(?<=({#for\\s(\\w)*\\s))in",
+          "name": "keyword.control.flow"
         }
       ]
     },
@@ -382,10 +390,6 @@
         {
           "match": "\\bthis\\b",
           "name": "variable.language.this.java"
-        },
-        {
-          "match": "\\b(in|is|as|eq|ne|gt|ge|lt|le)\\b",
-          "name": "keyword.operator"
         }
       ]
     },


### PR DESCRIPTION
Improved syntax coloration for Qute `in` keyword.
![Screenshot from 2022-01-20 14-43-09](https://user-images.githubusercontent.com/26389510/150410909-66c3d091-3008-49d5-b457-6b5439e4e166.png)

Part of #428 

Signed-off-by: Alexander Chen <alchen@redhat.com>