### PR TITLE
Added `qute.templates.languageMismatch` to avoid reuse of `quarkus.tools.propertiesLanguageMismatch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,16 +207,32 @@
           "type": "string",
           "enum": [
             "ignore",
-            "forceQuarkus",
+            "force",
             "prompt"
           ],
           "enumDescriptions": [
-            "ignore language mismatch for Quarkus properties",
+            "Ignore language mismatch for Quarkus properties",
             "Automatically correct the language for mismatched Quarkus properties",
             "Prompt correcting the language for mismatched Quarkus properties"
           ],
-          "default": "forceQuarkus",
+          "default": "force",
           "description": "Action performed when detected Quarkus properties have an incorrect language.",
+          "scope": "window"
+        },
+        "qute.templates.languageMismatch": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "force",
+            "prompt"
+          ],
+          "enumDescriptions": [
+            "Ignore language mismatch for Qute templates",
+            "Automatically correct the language for mismatched Qute templates",
+            "Prompt correcting the language for mismatched Qute templates"
+          ],
+          "default": "force",
+          "description": "Action performed when detected Qute templates have an incorrect language.",
           "scope": "window"
         },
         "qute.trace.server": {

--- a/src/QuarkusConfig.ts
+++ b/src/QuarkusConfig.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_API_URL,
 } from './definitions/constants';
 import { ConfigurationTarget, workspace } from 'vscode';
+import { LanguageMismatch } from './utils/languageMismatch';
 
 /**
  * This class manages the extension's interaction with
@@ -30,7 +31,7 @@ export namespace QuarkusConfig {
   export const STARTER_SHOW_EXT_DESC = 'quarkus.tools.starter.showExtensionDescriptions';
   export const ALWAYS_SHOW_WELCOME_PAGE = 'quarkus.tools.alwaysShowWelcomePage';
   export const DEBUG_TERMINATE_ON_EXIT = 'quarkus.tools.debug.terminateProcessOnExit';
-  export const PROPERTIES_LANGUAGE_MISMATCH = "quarkus.tools.propertiesLanguageMismatch";
+  export const QUARKUS_PROPERTIES_LANGUAGE_MISMATCH = "quarkus.tools.propertiesLanguageMismatch";
   export const QUARKUS_OVERRIDE_LANGUAGE_ID = 'quarkus.tools.override.languageId';
 
   export function getApiUrl(): string {
@@ -52,8 +53,8 @@ export namespace QuarkusConfig {
     return workspace.getConfiguration().get<TerminateProcessConfig>(DEBUG_TERMINATE_ON_EXIT);
   }
 
-  export function getPropertiesLanguageMismatch(): PropertiesLanguageMismatch {
-    return workspace.getConfiguration().get<PropertiesLanguageMismatch>(PROPERTIES_LANGUAGE_MISMATCH);
+  export function getPropertiesLanguageMismatch(): QuarkusPropertiesLanguageMismatch {
+    return workspace.getConfiguration().get<QuarkusPropertiesLanguageMismatch>(QUARKUS_PROPERTIES_LANGUAGE_MISMATCH);
   }
 
   export function setAlwaysShowWelcomePage(value: boolean): void {
@@ -68,8 +69,8 @@ export namespace QuarkusConfig {
     saveToQuarkusConfig(DEBUG_TERMINATE_ON_EXIT, value);
   }
 
-  export function setPropertiesLanguageMismatch(value: PropertiesLanguageMismatch): Thenable<void> {
-    return saveToQuarkusConfig(PROPERTIES_LANGUAGE_MISMATCH, value);
+  export function setPropertiesLanguageMismatch(value: QuarkusPropertiesLanguageMismatch): Thenable<void> {
+    return saveToQuarkusConfig(QUARKUS_PROPERTIES_LANGUAGE_MISMATCH, value);
   }
 
   export function saveToQuarkusConfig<T>(configName: string, value: T): Thenable<void> {
@@ -83,8 +84,4 @@ export enum TerminateProcessConfig {
   DontTerminate = "Never terminate"
 }
 
-export enum PropertiesLanguageMismatch {
-  ignore = "ignore",
-  forceQuarkus = "forceQuarkus",
-  prompt = "prompt"
-}
+export class QuarkusPropertiesLanguageMismatch extends LanguageMismatch {}

--- a/src/qute/languageServer/settings.ts
+++ b/src/qute/languageServer/settings.ts
@@ -1,3 +1,5 @@
+import { ConfigurationTarget, workspace } from 'vscode';
+import { LanguageMismatch } from '../../utils/languageMismatch';
 /**
  * VScode Qute settings.
  */
@@ -17,4 +19,20 @@ export namespace QuteSettings {
    * Disable Qute validation for the given file name patterns settings.
    */
   export const QUTE_VALIDATION_EXCLUDED = 'qute.validation.excluded';
+
+  /**
+   * Action performed when detected Qute templates have an incorrect language.
+   */
+  export const QUTE_TEMPLATES_LANGUAGE_MISMATCH = "qute.templates.languageMismatch";
+
+  /**
+   * Flag for enabling forcing Qute language id setting
+   */
+  export const QUTE_OVERRIDE_LANGUAGE_ID = 'qute.templates.override.languageId';
+
+  export function getQuteTemplatesLanguageMismatch(): QuteTemplateLanguageMismatch {
+    return workspace.getConfiguration().get<QuteTemplateLanguageMismatch>(QUTE_TEMPLATES_LANGUAGE_MISMATCH);
+  }
 }
+
+export class QuteTemplateLanguageMismatch extends LanguageMismatch {}

--- a/src/utils/languageMismatch.ts
+++ b/src/utils/languageMismatch.ts
@@ -1,0 +1,71 @@
+import { commands, ConfigurationTarget, ExtensionContext, languages, TextDocument, window, workspace } from "vscode";
+import { ProjectLabelInfo } from "../definitions/ProjectLabelInfo";
+
+export abstract class LanguageMismatch {
+  static ignore: string = "ignore";
+  static force: string = "force";
+  static prompt: string = "prompt";
+
+  static setLanguageMismatch(configName: string, value: string): Thenable<void> {
+    return this.saveToConfig(configName, value);
+  }
+
+  static saveToConfig<T>(configName: string, value: T): Thenable<void> {
+    return workspace.getConfiguration().update(configName, value, ConfigurationTarget.Global);
+  }
+}
+
+/**
+ * Try to force the document language ID to the given language ID.
+ *
+ * @param document the text document.
+ * @param languageId the language ID.
+ * @param notifyUser if a notification should appear when the language ID is updated
+ */
+export function tryToForceLanguageId(context: ExtensionContext, document: TextDocument, fileName: string, propertiesLanguageMismatch: LanguageMismatch, languageId: string, notifyUser: boolean, popupFlag: string, mismatchSetting: string): Promise<void> {
+  // Get project label information for the given file URI
+  const labelInfo = ProjectLabelInfo.getProjectLabelInfo(document.uri.toString());
+  return labelInfo.then(l => {
+    if (l.isQuarkusProject()) {
+      if (propertiesLanguageMismatch === LanguageMismatch.prompt) {
+        const YES = "Yes", NO = "No";
+        const supportType = languageId.indexOf('qute') > -1 ? 'Qute' : 'Quarkus';
+        const response: Thenable<string> = window.showInformationMessage(`The language ID for '${fileName}' must be '${languageId}' to receive '${supportType}' support. Set the language ID to '${languageId}?'`, YES, NO);
+        response.then(result => {
+          if (result === YES) {
+            // The file belongs to a Quarkus project, force a corresponding language
+            languages.setTextDocumentLanguage(document, languageId);
+          }
+        });
+      } else if (propertiesLanguageMismatch === LanguageMismatch.force || propertiesLanguageMismatch === "forceQuarkus") {
+        // The file belongs to a Quarkus project, force a corresponding language
+        const oldLanguageId: string = document.languageId;
+        languages.setTextDocumentLanguage(document, languageId);
+        if (notifyUser) {
+          if (!hasShownSetLanguagePopUp(context, popupFlag)) {
+            const CONFIGURE_IN_SETTINGS = "Configure in Settings";
+            const DISABLE_IN_SETTINGS = "Disable Language Updating";
+            const response: Thenable<string> = window.showInformationMessage(
+              `Quarkus Tools for Visual Studio Code automatically switched the language ID of '${fileName}' `
+              + `to be '${languageId}' in order to provide language support. `
+              + `This behavior can be configured in settings.`, DISABLE_IN_SETTINGS, CONFIGURE_IN_SETTINGS);
+            response.then(result => {
+              if (result === CONFIGURE_IN_SETTINGS) {
+                commands.executeCommand('workbench.action.openSettings', mismatchSetting);
+              } else if (result === DISABLE_IN_SETTINGS) {
+                LanguageMismatch.setLanguageMismatch(mismatchSetting, LanguageMismatch.ignore).then(() => {
+                  languages.setTextDocumentLanguage(document, oldLanguageId);
+                });
+              }
+            });
+            context.globalState.update(popupFlag, 'true');
+          }
+        }
+      }
+    }
+  });
+}
+
+function hasShownSetLanguagePopUp(context: ExtensionContext, flag: string): boolean {
+  return context.globalState.get(flag, false);
+}


### PR DESCRIPTION
Added `qute.templates.languageMismatch` to avoid reuse of `quarkus.tools.propertiesLanguageMismatch`.

All pop-ups and setting configurations are now Qute specific:
![Screenshot from 2022-02-09 15-53-54](https://user-images.githubusercontent.com/26389510/153288707-7b61f549-d249-436c-afc7-d68d04133a9e.png)
![Screenshot from 2022-02-09 15-54-05](https://user-images.githubusercontent.com/26389510/153288709-4f2f88e1-dc17-4a22-a054-28d3dad81ceb.png)
![Screenshot from 2022-02-09 15-54-36](https://user-images.githubusercontent.com/26389510/153288710-ba4db58b-afc3-4903-8246-b9cc04e4e3bf.png)

Fixes #457 

Signed-off-by: Alexander Chen <alchen@redhat.com>
