### PR TITLE
Use embedded JRE from redhat.java to launch Qute language server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ In `Java` files, you will benefit with:
 ## Requirements
 
   * [Visual Studio Code extension for MicroProfile](https://github.com/redhat-developer/vscode-microprofile)
-  * Java JDK (or JRE) 11 or more recent
+  * Java JDK (or JRE) 11 or more recent is required **except** on the following platforms : `win32-x64`, `linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`. See [JDK Tooling](https://github.com/redhat-developer/vscode-java/#java-tooling-jdk) for details.
   * [Language Support for Java(TM) by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.java)
   * [Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug)
 

--- a/src/qute/languageServer/client.ts
+++ b/src/qute/languageServer/client.ts
@@ -7,11 +7,12 @@ import { prepareExecutable } from './javaServerStarter';
 import { registerVSCodeQuteCommands } from '../commands/registerCommands';
 import { QuteClientCommandConstants } from '../commands/commandConstants';
 import { QuteSettings } from './settings';
+import { JavaExtensionAPI } from '../../extension';
 
-export function connectToQuteLS(context: ExtensionContext) {
+export function connectToQuteLS(context: ExtensionContext, api: JavaExtensionAPI) {
   registerVSCodeQuteCommands(context);
 
-  return requirements.resolveRequirements().then(requirements => {
+  return requirements.resolveRequirements(api).then(requirements => {
     const clientOptions: LanguageClientOptions = {
       documentSelector: [
         { scheme: 'file', language: 'qute-html' },

--- a/src/qute/languageServer/javaServerStarter.ts
+++ b/src/qute/languageServer/javaServerStarter.ts
@@ -15,7 +15,7 @@ export function prepareExecutable(requirements: RequirementsData): Executable {
   const options: ExecutableOptions = Object.create(null);
   options.env = process.env;
   executable.options = options;
-  executable.command = path.resolve(requirements.java_home + '/bin/java');
+  executable.command = path.resolve(requirements.tooling_jre + '/bin/java');
   executable.args = prepareParams();
   return executable;
 }

--- a/src/qute/languageServer/requirements.ts
+++ b/src/qute/languageServer/requirements.ts
@@ -7,10 +7,13 @@ import { Uri, workspace } from 'vscode';
 
 import * as expandHomeDir from 'expand-home-dir';
 import * as findJavaHome from 'find-java-home';
+import { JavaExtensionAPI } from '../../extension';
 const isWindows = process.platform.indexOf('win') === 0;
 const JAVA_FILENAME = 'java' + (isWindows?'.exe': '');
 
 export interface RequirementsData {
+    tooling_jre: string;
+    tooling_jre_version: number;
     java_home: string;
     java_version: number;
 }
@@ -22,10 +25,15 @@ export interface RequirementsData {
  * if any of the requirements fails to resolve.
  *
  */
-export async function resolveRequirements(): Promise<RequirementsData> {
+export async function resolveRequirements(api: JavaExtensionAPI): Promise<RequirementsData> {
+    // Use the embedded JRE from 'redhat.java' if it exists
+    if (api && api.javaRequirement) {
+        return Promise.resolve(api.javaRequirement);
+    }
+
     const javaHome = await checkJavaRuntime();
     const javaVersion = await checkJavaVersion(javaHome);
-    return Promise.resolve({ java_home: javaHome, java_version: javaVersion});
+    return Promise.resolve({tooling_jre: javaHome, tooling_jre_version: javaVersion, java_home: javaHome, java_version: javaVersion});
 }
 
 function checkJavaRuntime(): Promise<string> {


### PR DESCRIPTION
- Create helper method getJavaExtensionAPI so that it may be reused
- Use 'redhat.java' embedded JRE through RequirementsData from its
  ExtensionAPI
- Adjust README with new requirements

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>