### PR TITLE
Added validation severity setting for Qute `UndefinedObject` error

### DIFF
--- a/package.json
+++ b/package.json
@@ -259,6 +259,17 @@
           },
           "markdownDescription": "Disable Qute validation for the given file name patterns.\n\nExample:\n```\n[\n \"**/*items.qute.*\"\n]```.",
           "scope": "resource"
+        },
+        "qute.validation.undefinedObject.severity": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "warning",
+          "markdownDescription": "Validation severity for undefined object in Qute template files.",
+          "scope": "resource"
         }
       }
     },


### PR DESCRIPTION
Added validation severity setting for Qute `UndefinedObject` error.

Part of redhat-developer/quarkus-ls#451

Signed-off-by: Alexander Chen <alchen@redhat.com>