### PR TITLE
Added setting to disable Qute CodeLens in Qute templates

### DIFF
--- a/docs/qute/README.md
+++ b/docs/qute/README.md
@@ -9,6 +9,9 @@
 
  ## Settings
 
+ * `qute.codeLens.enabled`: Enable/disable Qute CodeLens. Default is `true`.
  * `qute.trace.server`: Trace the communication between VS Code and the Qute language server in the Output view. Default is `off`.
  * `qute.validation.enabled`: Enable/disable all Qute validation. Default is `false`.
  * `qute.validation.excluded`: Disable Qute validation for the given file name patterns.\n\nExample:\n```\n[\n \"**/*items.qute.*\"\n]```.
+ * `qute.validation.undefinedObject.severity`: Validation severity for undefined object in Qute template files. Default is `warning`.
+ * `qute.validation.undefinedNamespace.severity`: Validation severity for undefined namespace in Qute template files. Default is `warning`.

--- a/package.json
+++ b/package.json
@@ -218,6 +218,11 @@
           "description": "Action performed when detected Quarkus properties have an incorrect language.",
           "scope": "window"
         },
+        "qute.codeLens.enabled": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable/disable Qute CodeLens. Default is `true`."
+        },
         "qute.templates.languageMismatch": {
           "type": "string",
           "enum": [


### PR DESCRIPTION
Added setting to disable Qute CodeLens in Qute templates.
![qutecodelenssettingenabledisable](https://user-images.githubusercontent.com/26389510/158891616-8fc7732e-8833-423b-85fd-6d73d1b44161.gif)


Part of redhat-developer/quarkus-ls/issues/472 

Signed-off-by: Alexander Chen <alchen@redhat.com>