### PR TITLE
Improved Qute parameter declaration syntax colouration

### DIFF
--- a/language-support/qute/qute.tmLanguage.json
+++ b/language-support/qute/qute.tmLanguage.json
@@ -47,9 +47,43 @@
       ]
     },
     "parameter_declaration": {
-      "begin": "(?<!\\\\){@",
-      "end": "(?<!\\\\)}",
-      "name": "keyword.other.qute"
+      "begin": "({)(@)",
+      "beginCaptures": {
+				"1": {
+					"name": "support.constant.qute"
+				},
+        "2": {
+					"name": "keyword.other.qute"
+				}
+			},
+      "end": "((?<![\\\\])})",
+      "endCaptures": {
+        "0": {
+          "name": "support.constant.qute"
+        }
+      },
+      "patterns": [
+        {
+          "match": "(?<=\\s)([a-zA-Z0-9_-]+)(?=})",
+          "name": "variable.other.qute"
+        },
+        {
+          "match": "[a-zA-Z0-9_-]+",
+          "name": "entity.name.namespace"
+        },
+        {
+          "match": "(?<=\\w)[<>]",
+          "name": "punctuation.bracket.angle.java"
+        },
+        {
+          "match": "(?<=\\w)\\.",
+          "name": "punctuation.separator.java"
+        },
+        {
+          "match": "(?<=[\\s]*),",
+          "name": "punctuation.separator.java"
+        }
+      ]
     },
     "comment": {
       "begin": "{!",
@@ -96,7 +130,7 @@
       "end": "(\\/)?((?<![\\\\])})",
       "beginCaptures": {
         "1": {
-          "name": "support.constant.handlebars"
+          "name": "support.constant.qute"
         },
         "2": {
           "name": "keyword.control"
@@ -110,7 +144,7 @@
           "name": "keyword.control"
         },
         "2": {
-          "name": "support.constant.handlebars"
+          "name": "support.constant.qute"
         }
       },
       "patterns": [
@@ -124,7 +158,7 @@
       "end": "((?<![\\\\])})",
       "beginCaptures": {
         "1": {
-          "name": "support.constant.handlebars"
+          "name": "support.constant.qute"
         },
         "2": {
           "name": "keyword.control"
@@ -135,7 +169,7 @@
       },
       "endCaptures": {
         "1": {
-          "name": "support.constant.handlebars"
+          "name": "support.constant.qute"
         }
       }
     },
@@ -144,7 +178,7 @@
       "end": "(\\/)?((?<![\\\\])})",
       "beginCaptures": {
         "1": {
-          "name": "support.constant.handlebars"
+          "name": "support.constant.qute"
         },
         "2": {
           "name": "keyword.control"
@@ -158,7 +192,7 @@
           "name": "keyword.control"
         },
         "2": {
-          "name": "support.constant.handlebars"
+          "name": "support.constant.qute"
         }
       },
       "patterns": [
@@ -180,7 +214,7 @@
       "end": "(\\/)?((?<![\\\\])})",
       "beginCaptures": {
         "1": {
-          "name": "support.constant.handlebars"
+          "name": "support.constant.qute"
         },
         "2": {
           "name": "keyword.control"
@@ -194,7 +228,7 @@
           "name": "keyword.control"
         },
         "2": {
-          "name": "support.constant.handlebars"
+          "name": "support.constant.qute"
         }
       },
       "patterns": [
@@ -212,7 +246,7 @@
       "end": "(\\/)?((?<![\\\\])})",
       "beginCaptures": {
         "1": {
-          "name": "support.constant.handlebars"
+          "name": "support.constant.qute"
         },
         "2": {
           "name": "entity.name.function.hash"
@@ -226,7 +260,7 @@
           "name": "keyword.control"
         },
         "2": {
-          "name": "support.constant.handlebars"
+          "name": "support.constant.qute"
         }
       },
       "patterns": [
@@ -240,7 +274,7 @@
       "end": "((?<![\\\\])})",
       "beginCaptures": {
         "1": {
-          "name": "support.constant.handlebars"
+          "name": "support.constant.qute"
         },
         "2": {
           "name": "entity.name.function.slash"
@@ -251,7 +285,7 @@
       },
       "endCaptures": {
         "1": {
-          "name": "support.constant.handlebars"
+          "name": "support.constant.qute"
         }
       }
     },
@@ -263,12 +297,12 @@
       "end": "((?<![\\\\])})",
       "beginCaptures": {
         "1": {
-          "name": "support.constant.handlebars"
+          "name": "support.constant.qute"
         }
       },
       "endCaptures": {
         "1": {
-          "name": "support.constant.handlebars"
+          "name": "support.constant.qute"
         }
       },
       "patterns": [


### PR DESCRIPTION
Improved Qute parameter declaration syntax colouration and indentified Java qualified name in parameter.

Fixes: #488 

e.g. the following:
```qute
{@java.util.List<org.acme.qute.Item> items}
{@org.acme.qute.Item items}
{@java.util.Map<org.acme.qute.Item, org.acme.qute.Item> items}
```
is coloured as follows:
![Screenshot from 2022-04-08 09-47-01](https://user-images.githubusercontent.com/26389510/162448683-3e95895d-9cbc-4af4-945a-11a69add9202.png)


Signed-off-by: Alexander Chen <alchen@redhat.com>