### PR TITLE
Avoid use of 'install' in favour of 'verify' in packaging scripts.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,7 +48,7 @@ gulp.task('buildExtension', (done) => {
 });
 
 gulp.task('buildQuteServer', (done) => {
-  cp.execSync(mvnw() + ' clean install -DskipTests', { cwd: quteServerDir , stdio: 'inherit' });
+  cp.execSync(mvnw() + ' clean verify -DskipTests', { cwd: quteServerDir , stdio: 'inherit' });
   gulp.src(quteServerDir + '/target/' + quteServer)
     .pipe(gulp.dest('./server'));
   done();


### PR DESCRIPTION
- Only use 'install' goal if absolutely necessary (ie. the artifact will
  be used in a subsequent build, or call to 'mvn'

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>