### PR TITLE
Added command to bind `qute.inlayHint.enabled` to `editor.inlayHints.enabled`

### DIFF
--- a/src/qute/commands/commandConstants.ts
+++ b/src/qute/commands/commandConstants.ts
@@ -39,6 +39,11 @@ export namespace QuteClientCommandConstants {
   * Client command to execute an XML command on XML Language Server side.
   */
   export const EXECUTE_WORKSPACE_COMMAND = 'qute.workspace.executeCommand';
+
+  /**
+  * Bind Qute inlay hint setting to editor inlay hint setting.
+  */
+  export const BIND_QUTE_INLAY_HINT = 'bind.qute.inlayHint.enabled';
 }
 
 /**

--- a/src/qute/commands/registerCommands.ts
+++ b/src/qute/commands/registerCommands.ts
@@ -19,6 +19,7 @@ export function registerVSCodeQuteCommands(context: ExtensionContext) {
   registerJavaDefinitionCommand(context);
   registerConfigurationUpdateCommand(context);
   registerQuteValidationToggleCommand(context);
+  registerQuteInlayHintBindToEditorSetting(context);
   context.subscriptions.push(
     workspace.onDidOpenTextDocument((document) => {
       updateQuteLanguageId(context, document, true);
@@ -180,6 +181,20 @@ export function registerConfigurationUpdateCommand(context: ExtensionContext) {
         removeFromPreferenceArray(config, section, value);
         break;
       }
+    }
+  }));
+}
+
+export function registerQuteInlayHintBindToEditorSetting(context: ExtensionContext) {
+  context.subscriptions.push(commands.registerCommand(QuteClientCommandConstants.BIND_QUTE_INLAY_HINT, async () => {
+    const editorInlayHintSetting = workspace.getConfiguration().get<string>(`editor.inlayHints.enabled`, "on");
+    if (editorInlayHintSetting === "off") {
+      const edit = {
+        value: false,
+        editType: ConfigurationItemEditType.Add,
+        section: QuteSettings.QUTE_INLAY_HINT
+      } as ConfigurationItemEdit;
+      await commands.executeCommand(QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, edit);
     }
   }));
 }

--- a/src/qute/languageServer/settings.ts
+++ b/src/qute/languageServer/settings.ts
@@ -30,6 +30,11 @@ export namespace QuteSettings {
    */
   export const QUTE_OVERRIDE_LANGUAGE_ID = 'qute.templates.override.languageId';
 
+  /**
+  * Qute inlay hint setting.
+  */
+  export const QUTE_INLAY_HINT = 'qute.inlayHint.enabled';
+
   export function getQuteTemplatesLanguageMismatch(): QuteTemplateLanguageMismatch {
     return workspace.getConfiguration().get<QuteTemplateLanguageMismatch>(QUTE_TEMPLATES_LANGUAGE_MISMATCH);
   }


### PR DESCRIPTION
Added command to bind `qute.inlayHint.enabled` to `editor.inlayHints.enabled`.

Fixes #509 

Signed-off-by: AlexXuChen <alex.xu.chen@gmail.com>