### PR TITLE
Add support for pre-releases.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,13 +3,6 @@
 node('rhel8'){
     stage('Checkout repos') {
         deleteDir()
-        def hasLsp4mpDir = fileExists 'lsp4mp'
-        if (!hasLsp4mpDir){
-            sh 'mkdir lsp4mp'
-        }
-        dir ('lsp4mp') {
-            git url: 'https://github.com/eclipse/lsp4mp.git'
-        }
         def hasServerDir = fileExists 'quarkus-ls'
         if (!hasServerDir){
             sh 'mkdir quarkus-ls'
@@ -22,7 +15,7 @@ node('rhel8'){
             sh 'mkdir vscode-quarkus'
         }
         dir ('vscode-quarkus') {
-            git url: 'https://github.com/redhat-developer/vscode-quarkus.git'
+            git url: "https://github.com/${params.FORK}/vscode-quarkus.git"
         }
     }
 
@@ -54,10 +47,20 @@ node('rhel8'){
         }
     }
 
+    env.publishPreReleaseFlag = ""
+    if('true'.equals(publishPreRelease)){
+        stage("Prepare for pre-release") {
+            dir ('vscode-quarkus') {
+                sh "npx gulp prepare_pre_release"
+                env.publishPreReleaseFlag = "--pre-release"
+            }
+        }
+    }
+
     stage('Package') {
         dir ('vscode-quarkus') {
             def packageJson = readJSON file: 'package.json'
-            sh "vsce package -o ../vscode-quarkus-${packageJson.version}-${env.BUILD_NUMBER}.vsix"
+            sh "vsce package ${env.publishPreReleaseFlag} -o ../vscode-quarkus-${packageJson.version}-${env.BUILD_NUMBER}.vsix"
             sh "npm pack && mv vscode-quarkus-${packageJson.version}.tgz ../vscode-quarkus-${packageJson.version}-${env.BUILD_NUMBER}.tgz"
         }
     }
@@ -73,32 +76,41 @@ node('rhel8'){
         }
     }
 
-    if('true'.equals(publishToMarketPlace)){
-        timeout(time:5, unit:'DAYS') {
-            input message:'Approve deployment?', submitter: 'fbricon,rgrunber,azerr,davthomp'
+    if('true'.equals(publishToMarketPlace) || 'true'.equals(publishToOVSX) || 'true'.equals(publishPreRelease)){
+        if('true'.equals(publishToMarketPlace) || 'true'.equals(publishToOVSX)){
+            timeout(time:5, unit:'DAYS') {
+                input message:'Approve deployment?', submitter: 'fbricon,rgrunber,azerr,davthomp'
+            }
         }
 
         stage("Publish to Marketplaces") {
             unstash 'vsix'
             unstash 'tgz'
             def vsix = findFiles(glob: '**.vsix')
-            // VS Code Marketplace
-            withCredentials([[$class: 'StringBinding', credentialsId: 'vscode_java_marketplace', variable: 'TOKEN']]) {
-                sh 'vsce publish -p ${TOKEN} --packagePath' + " ${vsix[0].path}"
+
+            if ('true'.equals(publishToMarketPlace) || 'true'.equals(publishPreRelease)) {
+                // VS Code Marketplace
+                withCredentials([[$class: 'StringBinding', credentialsId: 'vscode_java_marketplace', variable: 'TOKEN']]) {
+                    sh 'vsce publish -p ${TOKEN} --packagePath' + " ${vsix[0].path}"
+                }
             }
 
-            // open-vsx Marketplace
-            sh 'npm install -g ovsx'
-            withCredentials([[$class: 'StringBinding', credentialsId: 'open-vsx-access-token', variable: 'OVSX_TOKEN']]) {
-              sh 'ovsx publish -p ${OVSX_TOKEN}' + " ${vsix[0].path}"
+            if ('true'.equals(publishToOVSX)) {
+                // open-vsx Marketplace
+                sh 'npm install -g ovsx'
+                withCredentials([[$class: 'StringBinding', credentialsId: 'open-vsx-access-token', variable: 'OVSX_TOKEN']]) {
+                    sh 'ovsx publish -p ${OVSX_TOKEN}' + " ${vsix[0].path}"
+                }
             }
 
             archiveArtifacts artifacts:"**.vsix,**.tgz"
 
-            stage "Promote the build to stable"
-            sh "sftp -C ${UPLOAD_LOCATION}/stable/vscode-quarkus/ <<< \$'put -p ${vsix[0].path}'"
-            def tgz = findFiles(glob: '**.tgz')
-            sh "sftp -C ${UPLOAD_LOCATION}/stable/vscode-quarkus/ <<< \$'put -p ${tgz[0].path}'"
+            if ('true'.equals(publishToMarketPlace)) {
+                stage "Promote the build to stable"
+                sh "sftp -C ${UPLOAD_LOCATION}/stable/vscode-quarkus/ <<< \$'put -p ${vsix[0].path}'"
+                def tgz = findFiles(glob: '**.tgz')
+                sh "sftp -C ${UPLOAD_LOCATION}/stable/vscode-quarkus/ <<< \$'put -p ${tgz[0].path}'"
+            }
         }
     }
 }


### PR DESCRIPTION
- Add prepare_pre_release gulp task
- Make better use of existing Jenkins parameters for FORK,
  publishPreRelease, publishToMarketPlace & publishToOVSX
- Remove unnecessary lsp4mp cloning logic

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>