### PR TITLE
Activation trigger should be more selective.

### DIFF
--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -13,17 +13,25 @@ import { generateProjectWizard } from "../wizards/generateProject/generationWiza
 const NOT_A_QUARKUS_PROJECT = new Error('No Quarkus projects were detected in this folder');
 const STANDARD_MODE_REQUEST_FAILED = new Error('Error occurred while requesting standard mode from the Java language server');
 
+
+export function registerVSCodeClientCommands(context: ExtensionContext): void {
+  /**
+   * Command for creating a Quarkus project
+   */
+  registerCommandWithTelemetry(context, VSCodeCommands.CREATE_PROJECT, generateProjectWizard, true);
+
+  /**
+   * Command for displaying welcome page
+   */
+  registerCommandWithTelemetry(context, VSCodeCommands.QUARKUS_WELCOME, async () => { WelcomeWebview.createOrShow(context); });
+}
+
 /**
  * Register the vscode-quarkus commands
  *
  * @param context the extension context
  */
 export function registerVSCodeCommands(context: ExtensionContext): void {
-
-  /**
-   * Command for creating a Quarkus project
-   */
-  registerCommandWithTelemetry(context, VSCodeCommands.CREATE_PROJECT, generateProjectWizard, true);
 
   /**
    * Command for adding Quarkus extensions to current Quarkus Maven project
@@ -35,11 +43,6 @@ export function registerVSCodeCommands(context: ExtensionContext): void {
    */
   registerCommandWithTelemetry(context, VSCodeCommands.DEBUG_QUARKUS_PROJECT, withStandardMode(startDebugging, "Debugging the extension"));
   registerCommandWithTelemetry(context, VSCodeCommands.DEBUG_QUARKUS_PROJECT + VSCodeCommands.SHORT_SUFFIX, withStandardMode(startDebugging, "Debugging the extension"));
-
-  /**
-   * Command for displaying welcome page
-   */
-  registerCommandWithTelemetry(context, VSCodeCommands.QUARKUS_WELCOME, async () => { WelcomeWebview.createOrShow(context); });
 
   /**
    * Command for deploying current Quarkus project to OpenShift with OpenShift Connector


### PR DESCRIPTION
- Fixes #497
- Only start language server(s) and contribute extension functionality
  if a Quarkus project is detected

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

There is one annoying flaw here. When `activate()` is called, we don't know which event caused the activation, which would be nice to know.

We want to know if the activation occurred due to `onLanguage:java` because there are other activation criteria (eg. `onCommand:quarkusTools.createProject`, `workspaceContains:**/src/main/resources/application.properties`) that should definitely activate the project no matter what. So we check the known text documents, and if one has a `java` language ID, then there's a good chance, that's what activated it.

This mostly works except for the case of opening a Java file where the workspace contains an `application.properties` in the appropriate location. We will attempt to re-validate that the project is really a Quarkus project through `isQuarkusProject` when arguably, we should just activate without checking.