### PR TITLE
Don't throw an error popup when Qute LS cancel the inlay hint process.

### DIFF
--- a/src/qute/languageServer/inlayHintsProvider.ts
+++ b/src/qute/languageServer/inlayHintsProvider.ts
@@ -25,6 +25,9 @@ export class QuteInlayHintsProvider implements InlayHintsProvider {
       }
       return asInlayHints(values, this.client);
     } catch (error) {
+      if (token.isCancellationRequested) {
+        return [];
+      }
       return this.client.handleFailedRequest(InlayHintRequest.type, token, error);
     }
   }


### PR DESCRIPTION
Don't throw an error popup when Qute LS cancel the inlay hint process.

Signed-off-by: azerr <azerr@redhat.com>