### PR TITLE
Provide syntax coloration for #fragment

### DIFF
--- a/language-support/qute/qute.tmLanguage.json
+++ b/language-support/qute/qute.tmLanguage.json
@@ -129,7 +129,7 @@
 			"name": "string.unquoted.cdata.qute"
 		},
     "section_start_default_tag": {
-      "begin": "({)(#)((each|else|eval|include|insert|set|let|with|switch|case|is|when)\\b)",
+      "begin": "({)(#)((each|else|eval|fragment|include|insert|set|let|with|switch|case|is|when)\\b)",
       "end": "(\\/)?((?<![\\\\])})",
       "beginCaptures": {
         "1": {
@@ -157,7 +157,7 @@
       ]
     },
     "section_end_default_tag": {
-      "begin": "({)(\\/)((each|else|else\\sif|eval|for|if|include|insert|set|let|with|switch|case|is|when)\\b)",
+      "begin": "({)(\\/)((each|else|else\\sif|eval|for|fragment|if|include|insert|set|let|with|switch|case|is|when)\\b)",
       "end": "((?<![\\\\])})",
       "beginCaptures": {
         "1": {


### PR DESCRIPTION
Provide syntax coloration for #fragment

![image](https://user-images.githubusercontent.com/1932211/212713538-30b5a39d-302e-4227-9f1f-8d50541e60e3.png)

See https://github.com/redhat-developer/vscode-quarkus/issues/563

Signed-off-by: azerr <azerr@redhat.com>