### PR TITLE
Wait on jdt.ls standard mode before issuing delegate commands

### DIFF
--- a/src/qute/languageServer/client.ts
+++ b/src/qute/languageServer/client.ts
@@ -57,8 +57,10 @@ export async function connectToQuteLS(context: ExtensionContext, api: JavaExtens
   };
 
   function bindQuteRequest(request: string) {
-    quteLanguageClient.onRequest(request, async (params: any) =>
-      <any>await commands.executeCommand("java.execute.workspaceCommand", request, params)
+    quteLanguageClient.onRequest(request, async (params: any) => {
+      await api.serverReady();
+      return commands.executeCommand("java.execute.workspaceCommand", request, params);
+    }
     );
   }
 


### PR DESCRIPTION
Use the API to wait until jdt.ls is running before issuing commands to it. This bug is happening, since jdt.ls is no longer guaranteed to be running when vscode-quarkus launches.

Fixes #586

Signed-off-by: David Thompson <davthomp@redhat.com>
