### PR TITLE
Show validation errors for Qute project without opening a Qute template file

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "workspaceContains:**src/main/resources/META-INF/microprofile-config.properties",
     "workspaceContains:**/src/main/resources/application.yaml",
     "workspaceContains:**/src/main/resources/application.yml",
+    "workspaceContains:**/src/main/resources/templates",
     "onLanguage:microprofile-properties",
     "onLanguage:quarkus-properties",
     "onLanguage:java",


### PR DESCRIPTION
Show validation errors for Qute project without opening a Qute template file

See https://github.com/redhat-developer/quarkus-ls/issues/813