### PR TITLE
Check out the tag of quarkus-ls specified by `QUARKUS_LS_TAG`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,9 @@ node('rhel8'){
             sh 'mkdir quarkus-ls'
         }
         dir ('quarkus-ls') {
+            echo "Checking out quarkus-ls ${params.QUARKUS_LS_TAG}"
             git url: 'https://github.com/redhat-developer/quarkus-ls.git'
+            sh "git checkout ${params.QUARKUS_LS_TAG}"
         }
         def hasClientDir = fileExists 'vscode-quarkus'
         if (!hasClientDir) {


### PR DESCRIPTION
References a new parameter `QUARKUS_LS_TAG`, and checks out this tag of quarkus-ls after cloning the repo. Copied from vscode-microprofile.

Closes #602

Signed-off-by: David Thompson <davthomp@redhat.com>
