### PR TITLE
Handle telemetry/event coming from the Qute language server.

### DIFF
--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -23,6 +23,7 @@ vscode-quarkus has opt-in telemetry collection, provided by [vscode-redhat-telem
     * "Quarkus: Build executable"
  * vscode-quarkus emits telemetry when a recommendation to install a 3rd party extension is proposed.
    The telemetry contains the extension name and the choice made.
+ * vscode-quarkus emits telemetry to indicate whether a Qute template file has been opened.
 
 ## How to opt in or out
 

--- a/src/qute/languageServer/client.ts
+++ b/src/qute/languageServer/client.ts
@@ -1,7 +1,9 @@
+import { TelemetryEvent } from '@redhat-developer/vscode-redhat-telemetry/lib';
 import { commands, ConfigurationTarget, ExtensionContext, window, workspace } from 'vscode';
 import { DidChangeConfigurationNotification, LanguageClientOptions } from 'vscode-languageclient';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { JavaExtensionAPI } from '../../extension';
+import { sendTelemetry } from '../../utils/telemetryUtils';
 import { QuteClientCommandConstants } from '../commands/commandConstants';
 import { registerQuteLSDependentCommands, registerVSCodeQuteCommands, synchronizeQuteValidationButton } from '../commands/registerCommands';
 import { prepareExecutable } from './quteServerStarter';
@@ -119,6 +121,9 @@ export async function connectToQuteLS(context: ExtensionContext, api: JavaExtens
       }
     }
   }
+  quteLanguageClient.onTelemetry(async (e: TelemetryEvent) => {
+    sendTelemetry(e.name, e.properties);
+  });
   await setQuteValidationEnabledContext();
   await synchronizeQuteValidationButton(window.activeTextEditor);
   return quteLanguageClient;


### PR DESCRIPTION
- Requires https://github.com/redhat-developer/quarkus-ls/pull/917 (or any `telemetry/event` sent from the server)