### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
This enables dependabot to create PRs that update npm dependencies to the latest version.

This has been helpful in keeping dependencies up to date in vscode-openshift-toolkit, and I think it could be helpful here as well.

Signed-off-by: David Thompson <davthomp@redhat.com>
