### PR TITLE
Migrate Jenkins release job to GitHub Actions.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,158 @@
+name: release
+
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+    inputs:
+      QUARKUS_LS_TAG:
+        description: "branch/tag of the Quarkus language server to build."
+        type: string
+        default: master
+      publishPreRelease:
+        description: "Publish a pre-release ?"
+        required: true
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "true"
+      publishToMarketPlace:
+        description: "Publish to VS Code Marketplace ?"
+        required: true
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "false"
+      publishToOVSX:
+        description: "Publish to OpenVSX Registry ?"
+        required: true
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "false"
+jobs:
+  should-build-change:
+    runs-on: ubuntu-latest
+    outputs:
+      repo-cache-hit: ${{ steps.cache-last-commit.outputs.cache-hit }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: "redhat-developer/quarkus-ls"
+          fetch-depth: 2
+          path: quarkus-ls
+      - uses: actions/checkout@v4
+        with:
+          repository: "redhat-developer/vscode-quarkus"
+          fetch-depth: 2
+          path: vscode-quarkus
+      - run: |
+          pushd quarkus-ls
+          git rev-parse HEAD >> ../lastCommit
+          popd
+          pushd vscode-quarkus
+          git rev-parse HEAD >> ../lastCommit
+      - name: Check New Changes
+        id: cache-last-commit
+        uses: actions/cache@v4
+        with:
+          path: lastCommit
+          key: lastCommit-${{ hashFiles('lastCommit') }}
+  packaging-job:
+    runs-on: ubuntu-latest
+    needs: should-build-change
+    if: ${{ needs.should-build-change.outputs.repo-cache-hit != 'true' || github.event_name != 'schedule' }}
+    steps:
+      - name: Checkout Quarkus LS
+        uses: actions/checkout@v4
+        with:
+          repository: redhat-developer/quarkus-ls
+          ref: ${{ inputs.QUARKUS_LS_TAG }}
+          path: quarkus-ls
+      - name: Cache Maven local repository
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.m2/wrapper
+            !~/.m2/repository/com/redhat/microprofile
+          key: maven-local-${{ hashFiles('**/pom.xml') }}
+      - name: Set Up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Check Out VS Code Quarkus
+        uses: actions/checkout@v4
+        with:
+          path: vscode-quarkus
+      - name: Set Up NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install NodeJS dependencies
+        run: npm install -g typescript "@vscode/vsce" "ovsx"
+      - name: Build Extension
+        run: |
+          pushd vscode-quarkus
+          echo "EXT_VERSION=$(cat package.json | jq -r .version)" >> $GITHUB_ENV
+          npm install
+          npm run build
+          npm run vscode:prepublish
+      - name: Test vscode-quarkus
+        run: |
+          pushd vscode-quarkus
+          echo "xvfb-run --auto-servernum npm run test --silent
+        continue-on-error: true
+      - name: Prepare Pre-Release
+        if: ${{ github.event_name == 'schedule' || inputs.publishPreRelease == 'true' }}
+        run: |
+          pushd vscode-quarkus
+          npx gulp prepare_pre_release
+          echo "publishPreReleaseFlag=--pre-release" >> $GITHUB_ENV
+      - name: Package vscode-quarkus
+        run: |
+          pushd vscode-quarkus
+          vsce package ${{ env.publishPreReleaseFlag }} -o ../vscode-quarkus-${{ env.EXT_VERSION }}-${GITHUB_RUN_NUMBER}.vsix
+      - name: Upload VSIX Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-quarkus
+          path: |
+            vscode-quarkus-${{ env.EXT_VERSION }}-${{github.run_number}}.vsix
+          if-no-files-found: error
+      - name: Publish to GH Release Tab
+        if: ${{ inputs.publishToMarketPlace == 'true' && inputs.publishToOVSX == 'true' }}
+        uses: "marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "${{ env.EXT_VERSION }}"
+          title: "${{ env.EXT_VERSION }}"
+          draft: true
+          files: |
+              vscode-quarkus-${{ env.EXT_VERSION }}-${{ github.run_number }}.vsix
+  release-job:
+    environment: ${{ (inputs.publishToMarketPlace == 'true' || inputs.publishToOVSX == 'true') && 'release' || 'pre-release' }}
+    runs-on: ubuntu-latest
+    needs: packaging-job
+    steps:
+      - name: Set Up NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: |
+          npm install -g typescript "@vscode/vsce" "ovsx"
+      - name: Download VSIX
+        uses: actions/download-artifact@v4
+      - name: Publish to VS Code Marketplace
+        if: ${{ github.event_name == 'schedule' || inputs.publishToMarketPlace == 'true' || inputs.publishPreRelease == 'true' }}
+        run: |
+          vsce publish -p ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} --packagePath vscode-quarkus/vscode-quarkus-*-${GITHUB_RUN_NUMBER}.vsix
+      - name: Publish to OpenVSX Registry
+        if: ${{ github.event_name == 'schedule' || inputs.publishToOVSX == 'true' || inputs.publishPreRelease == 'true' }}
+        run: |
+          ovsx publish -p ${{ secrets.OVSX_MARKETPLACE_TOKEN }}  --packagePath vscode-quarkus/vscode-quarkus-*-${GITHUB_RUN_NUMBER}.vsix

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,6 @@
 .vscode
 .gitignore
+.github/
 .travis.yml
 .vscode-test/
 node_modules/


### PR DESCRIPTION
- Preserve existing Jenkinsfile as a fallback

This is nearly identical to https://github.com/redhat-developer/vscode-microprofile/blob/master/.github/workflows/release.yml with lsp4mp replaced with quarkus-ls & vscode-microprofile -> vscode-quarkus.