### PR TITLE
fix: set platformOnly to false to collect all extensions in the wizard

### DIFF
--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -30,7 +30,7 @@ const HEADERS = {
 };
 
 export async function getQExtensions(platform?: string): Promise<QExtension[]> {
-  const apiUrl = `${QuarkusConfig.getApiUrl()}/extensions${platform === undefined ? `` : `/stream/${platform}`}`;
+  const apiUrl = `${QuarkusConfig.getApiUrl()}/extensions${platform === undefined ? `` : `/stream/${platform}`}?platformOnly=false`;
   const extensions: APIExtension[] = await tryGetExtensionsJSON(apiUrl);
   const qExtensions: QExtension[] = extensions.map((ext: APIExtension) => {
     return convertToQExtension(ext);


### PR DESCRIPTION
This PR allows to show Quarkus extensions without the platformOnly filter which allows to show langChain4j extensions:

![image](https://github.com/user-attachments/assets/1ce549d7-3137-4174-8e6d-a52cc063e78c)
