### PR TITLE
Force language to 'quarkus-properties' doesn't work for application.properties

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,7 +116,7 @@ function displayWelcomePageIfNeeded(context: ExtensionContext): void {
   }
 }
 
-const APP_PROPERTIES_PATTERN = /^application(?:-[A-Za-z]+)\.properties$/;
+const APP_PROPERTIES_PATTERN = /^application(?:-[A-Za-z]+)?\.properties$/;
 
 /**
  * Update if required the language ID to 'quarkus-properties' if needed.


### PR DESCRIPTION
Force language to 'quarkus-properties' doesn't work for application.properties

To test this PR, install Spring extension which will set the application.properties to Spring Boot:

![image](https://github.com/user-attachments/assets/c2956b92-606f-44db-8bba-19738976d72b)

After loading the Java project, the application.properties language must be forced to Quarkus, but it doesn't work.

The PR fixes the regexp to accept only `application.properties`