### PR TITLE
Update @types/chai to latest compatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.15.0",
-        "@types/chai": "^4.3.16",
+        "@types/chai": "^4.3.20",
         "@types/chai-fs": "^2.0.5",
         "@types/ejs": "^3.1.5",
         "@types/fs-extra": "^11.0.4",
@@ -995,9 +995,9 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.3.16",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.16.tgz",
-      "integrity": "sha512-PatH4iOdyh3MyWtmHVFXLWCCIhUbopaltqddG9BzB+gMIzee2MJrvd+jouii9Z3wzQJruGWAm7WOMjgfG8hQlQ==",
+      "version": "4.3.20",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
+      "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
       "dev": true
     },
     "node_modules/@types/chai-fs": {

--- a/package.json
+++ b/package.json
@@ -444,7 +444,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",
-    "@types/chai": "^4.3.16",
+    "@types/chai": "^4.3.20",
     "@types/chai-fs": "^2.0.5",
     "@types/ejs": "^3.1.5",
     "@types/fs-extra": "^11.0.4",


### PR DESCRIPTION
We can't use chai 5 since it requires ES Modules and drops support for chai-fs