### PR TITLE
Fix cron expression for dependabot schedule

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: "cron"
-    cronjob: 0 0 8 * * 2,4 *
+    cronjob: 0 8 * * 2,4
   open-pull-requests-limit: 10
   groups:
     typescript-eslint:


### PR DESCRIPTION
It seems like it only accepts 5 part expressions, and I supplied a 7 part expression.