### PR TITLE
Integrate Qute Debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,6 +185,43 @@
         "category": "Qute"
       }
     ],
+    "breakpoints": [
+      {
+        "language": "qute-html"
+      },
+      {
+        "language": "qute-json"
+      },
+      {
+        "language": "qute-yaml"
+      },
+      {
+        "language": "qute-txt"
+      }
+    ],
+    "debuggers": [
+      {
+        "type": "qute",
+        "label": "Qute Debugger",
+        "languages": [
+          "qute-html",
+          "qute-json",
+          "qute-yaml",
+          "qute-txt"
+        ],
+        "configurationAttributes": {
+          "attach": {
+            "required": ["port"],
+            "properties": {
+              "port": {
+                "type": "number",
+                "description": "TCP port of the Qute DAP server"
+              }
+            }
+          }
+        }
+      }
+    ],
     "configuration": {
       "title": "Quarkus Tools",
       "properties": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@
  */
 import { readFile } from 'fs-extra';
 import * as path from 'path';
-import { commands, Disposable, ExtensionContext, extensions, Terminal, TextDocument, window, workspace } from 'vscode';
+import { commands, Disposable, ExtensionContext, extensions, Terminal, TextDocument, window, workspace, debug } from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { registerVSCodeClientCommands, registerVSCodeCommands } from './commands/registerCommands';
 import { QuarkusConfig, QuarkusPropertiesLanguageMismatch } from './QuarkusConfig';
@@ -30,6 +30,7 @@ import { initTelemetryService } from './utils/telemetryUtils';
 import { getFilePathsFromWorkspace } from './utils/workspaceUtils';
 import { WelcomeWebview } from './webviews/WelcomeWebview';
 import { createTerminateDebugListener } from './wizards/debugging/terminateProcess';
+import { QuteDebugAdapterFactory } from './qute/debugAdapter/quteDebugAdapterFactory';
 
 // alias for vscode-java's ExtensionAPI
 export type JavaExtensionAPI = any;
@@ -57,6 +58,12 @@ export async function activate(context: ExtensionContext) {
   } else {
     doActivate(context);
   }
+
+  // Register the Qute Debugger
+  const quteDebugFactory = new QuteDebugAdapterFactory();
+  context.subscriptions.push(
+    debug.registerDebugAdapterDescriptorFactory('qute', quteDebugFactory)
+  );
 }
 
 async function doActivate(context: ExtensionContext): Promise<void> {
@@ -101,7 +108,6 @@ async function doActivate(context: ExtensionContext): Promise<void> {
         }
       });
   }
-
 }
 
 export async function deactivate(): Promise<void> {

--- a/src/qute/debugAdapter/quteDebugAdapterFactory.ts
+++ b/src/qute/debugAdapter/quteDebugAdapterFactory.ts
@@ -1,0 +1,10 @@
+import * as vscode from 'vscode';
+
+export class QuteDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory {
+    createDebugAdapterDescriptor(
+        session: vscode.DebugSession
+    ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+        const port = session.configuration.port ?? 4711; // default port if not specified
+        return new vscode.DebugAdapterServer(port, '127.0.0.1');
+    }
+}


### PR DESCRIPTION
Integrate Qute Debugger

Fixes #1096

This PR provides a basic integration of the future Qute Debugger. This integration must be improved in the future to avoid doing some configuration. But let start with this PR.

To test this PR:

 * get the PR from Quarkus https://github.com/quarkusio/quarkus/pull/48962
 * build Quarkus https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md#building-main or only Qute artifacts that you need (see pom.xml with dependencies that you will to do in the previous comment)
 * launch this PR to open a seconf vscode windows with this Attach Qute debugger DAP support
 * Create or open a Qute project
 * Add in the pom.xml of the Qute project

```xml
        <dependency>
            <groupId>io.quarkus.qute</groupId>
            <artifactId>qute-core</artifactId>
            <version>999-SNAPSHOT</version>
        </dependency>
        <dependency>
            <groupId>io.quarkus.qute</groupId>
            <artifactId>qute-debug</artifactId>
            <version>999-SNAPSHOT</version>
        </dependency>
        <dependency>
            <groupId>io.quarkus</groupId>
            <artifactId>quarkus-qute</artifactId>
            <version>999-SNAPSHOT</version>
        </dependency>
        <dependency>
            <groupId>io.quarkus</groupId>
            <artifactId>quarkus-qute-deployment</artifactId>
            <version>999-SNAPSHOT</version>
        </dependency>
```

 * add in the launch.json the Qute attach debugger which will start the Qute debugger on 4711 port:

```
{
    "version": "0.2.0",
    "configurations": [
...
        {
            "type": "qute",
            "request": "attach",
            "name": "Attach to Qute Debugger",
            "port": 4711
        }
    ]
}
```

 * in tasks.json you need to set the Qute debug port

```
"command": "./mvnw quarkus:dev -DquteDebugPort=4711",
"windows": {
	"command": ".\\mvnw.cmd quarkus:dev -DquteDebugPort=4711"
}
```

 * set a breakpoint to a Qute template
 * open the HTML page
 * The HTML rendering of Qut etemplate must be stopped with th ebreakpoint
 * You can use console which should support completion, expression avaluation
 * Breakpoint condition

The Qute debugger is not perfect but don't hesitate to report any problem.

As you can see integration of Qute debugger (ex: update task.json, define Qute attach launch is very boring). It would be nice to improve that, but let's start with that for the moment.