### PR TITLE
Remove find-up dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@redhat-developer/vscode-redhat-telemetry": "^0.9.1",
         "ejs": "^3.1.10",
         "expand-home-dir": "0.0.3",
-        "find-up": "^7.0.0",
         "fs-extra": "^11.3.1",
         "glob": "^10.3.15",
         "jdk-utils": "^0.5.1",
@@ -4686,6 +4685,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
       "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
+      "dev": true,
       "dependencies": {
         "locate-path": "^7.2.0",
         "path-exists": "^5.0.0",
@@ -4702,6 +4702,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
       "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -6407,6 +6408,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
       "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dev": true,
       "dependencies": {
         "p-locate": "^6.0.0"
       },
@@ -7452,6 +7454,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
       "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
       "dependencies": {
         "yocto-queue": "^1.0.0"
       },
@@ -7466,6 +7469,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
       "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "dev": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -7477,6 +7481,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
       "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
       "dependencies": {
         "p-limit": "^4.0.0"
       },
@@ -9644,6 +9649,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
       "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
       "engines": {
         "node": ">=18"
       },

--- a/package.json
+++ b/package.json
@@ -527,7 +527,6 @@
     "@redhat-developer/vscode-redhat-telemetry": "^0.9.1",
     "ejs": "^3.1.10",
     "expand-home-dir": "0.0.3",
-    "find-up": "^7.0.0",
     "fs-extra": "^11.3.1",
     "glob": "^10.3.15",
     "jdk-utils": "^0.5.1",


### PR DESCRIPTION
It's a transitive dependency, so it shouldn't be listed as a direct dependency.