### PR TITLE
feat: Provide Qute snippet debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,7 +221,19 @@
               }
             }
           }
-        }
+        },
+         "configurationSnippets": [
+          {
+            "label": "Qute: Debug Qute templates",
+            "description": "Debug Qute templates from Quarkus Application",
+            "body": {
+              "name": "Debug Qute templates",
+              "type": "qute",
+              "request": "attach",
+              "port": 4971
+            }
+          }
+         ]
       }
     ],
     "configuration": {


### PR DESCRIPTION
feat: Provide Qute snippet debugger

Open a launch.json, you should have Qute debugging completion:

<img width="904" height="346" alt="image" src="https://github.com/user-attachments/assets/b73fa8e5-61b1-4352-8951-2f621c4bfa26" />

After completion apply:

<img width="742" height="406" alt="image" src="https://github.com/user-attachments/assets/7ddb16aa-683d-485a-9431-ea4c3baddd28" />
