### PR TITLE
Activate vscode-quarkus when Qute debug is launched.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "workspaceContains:**/src/main/resources/application.yml",
     "workspaceContains:**/src/main/resources/templates",
     "onLanguage:microprofile-properties",
-    "onLanguage:java"
+    "onLanguage:java",
+    "onDebugResolve:qute"
   ],
   "main": "./dist/extension",
   "extensionDependencies": [


### PR DESCRIPTION
This PR activate vscode-quarkus when user click on a launch which defines qute type debug adapter without waiting start of JDT LS or having src/main/resources/templates directory.