### PR TITLE
Support for debugging Qute template in Java annotation

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,8 @@
           "qute-html",
           "qute-json",
           "qute-yaml",
-          "qute-txt"
+          "qute-txt",
+          "java"
         ],
         "configurationAttributes": {
           "attach": {


### PR DESCRIPTION
Support for debugging Qute template in Java annotation:

<img width="1313" height="244" alt="image" src="https://github.com/user-attachments/assets/7e16fd6b-5d74-4ad6-a568-a8b8ee0eec3c" />

This PR requires:

 * PR from Quarkus LS https://github.com/redhat-developer/quarkus-ls/pull/1093
 * PR from Quarkus https://github.com/quarkusio/quarkus/pull/51454 (it require to cbuild Quarkus)

After building Quarkus debugger with  https://github.com/quarkusio/quarkus/pull/51454 and use Quarkus LS https://github.com/redhat-developer/quarkus-ls/pull/1093, you will need:

* to update your pom.xml to use Quarkus debugger https://github.com/quarkusio/quarkus/pull/51454  by adding:

```xml
<dependency>
      <groupId>io.quarkus.qute</groupId>
      <artifactId>qute-generator</artifactId>
      <version>999-SNAPSHOT</version>
  </dependency>
  <dependency>
      <groupId>io.quarkus.qute</groupId>
      <artifactId>qute-core</artifactId>
      <version>999-SNAPSHOT</version>
  </dependency>
  <dependency>
      <groupId>io.quarkus.qute</groupId>
      <artifactId>qute-debug</artifactId>
      <version>999-SNAPSHOT</version>
  </dependency>
  <dependency>
      <groupId>io.quarkus</groupId>
      <artifactId>quarkus-qute</artifactId>
      <version>999-SNAPSHOT</version>
  </dependency>
  <dependency>
      <groupId>io.quarkus</groupId>
      <artifactId>quarkus-qute-deployment</artifactId>
      <version>999-SNAPSHOT</version>
  </dependency>

```

* create a class with `@TemplateContents` like this:

```java
package org.acme.quarkus.sample;

import io.quarkus.qute.TemplateContents;
import jakarta.ws.rs.GET;
import jakarta.ws.rs.Path;
import jakarta.ws.rs.QueryParam;

import io.quarkus.qute.TemplateInstance;

@Path("hello")
public class HelloResource {

    @TemplateContents(value = "<p>Hello {name}!</p>")
    record Hello(String name) implements TemplateInstance {}

    @GET
    public TemplateInstance get(@QueryParam("name") String name) {
        return new Hello(name); 
    }
}
```

 * defines a launch (in launch.json) for Qute debugger like this:
 

```json
{
      "name": "Debugging Qute Templates",
      "type": "qute",
      "request": "attach",
      "port": 4971
  }
```

* update `task.json` with `"command": "./mvnw quarkus:dev -DquteDebugPort=4971",` (or start Quarkus app with the command `quarkus:dev -DquteDebugPort=4971`
 
 * start Quarkus app
 * start Qute debugger (update `task.json` with `"command": "./mvnw quarkus:dev -DquteDebugPort=4971",`
 * set a breakpoint in `@TemplateContents `line.
 * open your browser with `http://localhost:8080/hello`
 * breakpoint should be suspended

<img width="1313" height="244" alt="image" src="https://github.com/user-attachments/assets/b2ac95c1-317f-4558-b1b4-1e09266dcd1e" />
