### PR TITLE
(Re)Bind LSP request 'qute/template/projects'

### DIFF
--- a/src/qute/languageServer/client.ts
+++ b/src/qute/languageServer/client.ts
@@ -79,6 +79,7 @@ export async function connectToQuteLS(context: ExtensionContext, api: JavaExtens
 
   commands.executeCommand('setContext', 'QuteLSReady', true);
 
+  bindQuteRequest('qute/template/projects');
   bindQuteRequest('qute/template/project');
   bindQuteRequest('qute/template/projectDataModel');
   bindQuteRequest('qute/template/userTags');


### PR DESCRIPTION
(Re)Bind LSP request 'qute/template/projects'

I have noticed that the LSP request  'qute/template/projects' binding has been removed from 2 years!

We need this LSP request to load Qute projects when Qute LS starts (you should see Loading in the progress 

<img width="788" height="170" alt="image" src="https://github.com/user-attachments/assets/617b49e0-ab05-499e-9ac8-bfdc35a23e39" />