### PR TITLE
Activate vscode-quarkus on templates folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "workspaceContains:**src/main/resources/META-INF/microprofile-config.properties",
     "workspaceContains:**/src/main/resources/application.yaml",
     "workspaceContains:**/src/main/resources/application.yml",
-    "workspaceContains:**/src/main/resources/templates",
+    "workspaceContains:**/templates",
+    "workspaceContains:templates",
     "onLanguage:microprofile-properties",
     "onLanguage:java",
     "onDebugResolve:qute"


### PR DESCRIPTION
Activate vscode-quarkus on templates folder

Roq Application defines templates folder on the project root folder. This PR provides the capability to activate vscode-quarkus for Roq project.

Sample: https://github.com/ia3andy/the-code-site