### PR TITLE
Support for editor.action.triggerSuggest

### DIFF
--- a/src/qute/commands/commandConstants.ts
+++ b/src/qute/commands/commandConstants.ts
@@ -6,6 +6,11 @@
 export namespace QuteClientCommandConstants {
 
   /**
+   * Client command to trigger completion of the current offset
+   */
+  export const COMMAND_EDITOR_ACTION_TRIGGET_SUGGEST = 'editor.action.triggerSuggest';
+
+  /**
    * Client command to open Qute template by file Uri.
    */
   export const OPEN_URI = 'qute.command.open.uri';

--- a/src/qute/languageServer/client.ts
+++ b/src/qute/languageServer/client.ts
@@ -35,7 +35,8 @@ export async function connectToQuteLS(context: ExtensionContext, api: JavaExtens
               QuteClientCommandConstants.OPEN_URI,
               QuteClientCommandConstants.JAVA_DEFINTION,
               QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE,
-              QuteClientCommandConstants.COMMAND_SHOW_REFERENCES
+              QuteClientCommandConstants.COMMAND_SHOW_REFERENCES,
+              QuteClientCommandConstants.COMMAND_EDITOR_ACTION_TRIGGET_SUGGEST
             ]
           }
         }


### PR DESCRIPTION
Notify to the Qute Languae Server that editor.action.triggerSuggest is supported.

This command is used for instance when layout from Roq Yaml frontmatter is applied, it will open the completion for available layouts.

Same thing for paginate yaml field which opens available collections.