### PR TITLE
Only suggest minor and patch level updates to `@types/node`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,11 @@ updates:
     interval: "cron"
     cronjob: 0 8 * * 2,4
   open-pull-requests-limit: 10
+  allow:
+  - dependency-name: "@types/node"
+    update-types:
+      - "version-update:semver-minor"
+      - "version-update:semver-patch"
   groups:
     typescript-eslint:
       patterns:


### PR DESCRIPTION
Configure Dependabot to only open PRs to update `@types/node` within the major version that we've configured.